### PR TITLE
DocLoc. Removed time from names of screenshots

### DIFF
--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/screenshots/ScreenshotsImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/screenshots/ScreenshotsImpl.kt
@@ -17,6 +17,10 @@ class ScreenshotsImpl(
     screenshotDir: File = File("screenshots")
 ) : Screenshots {
 
+    companion object {
+        private const val NAME_SEPARATOR = "_"
+    }
+
     private val screenshotFiles = ScreenshotFiles(screenshotDir)
 
     private val internalScreenshotMaker = InternalScreenshotMaker(screenshotFiles)
@@ -24,6 +28,9 @@ class ScreenshotsImpl(
 
     /**
      * Takes screenshot if it is possible, otherwise logs the error.
+     * The method adds System.currentTimeMillis() to the tag to save all screenshots of a test
+     *     running several times per the same suite. That's why a name will look
+     *     like "1570158949869_ScreenshotSampleTest_step_1".
      *
      * Required Permissions: WRITE_EXTERNAL_STORAGE.
      *
@@ -31,16 +38,17 @@ class ScreenshotsImpl(
      */
     override fun take(tag: String) {
         val resumedActivity = activities.getResumed()
+        val fullName = System.currentTimeMillis().toString() + NAME_SEPARATOR + tag
 
         if (resumedActivity != null) {
             runCatching {
-                internalScreenshotMaker.screenshot(resumedActivity, tag)
+                internalScreenshotMaker.screenshot(resumedActivity, fullName)
             }.onSuccess {
                 return
             }
         }
 
-        runCatching { externalScreenshotMaker.screenshot(tag) }
+        runCatching { externalScreenshotMaker.screenshot(fullName) }
             .onFailure { e -> logger.e("An error while making screenshot occurred: ${e.getStackTraceAsString()}") }
     }
 }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/screenshots/screenshoter/ScreenshotFiles.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/screenshots/screenshoter/ScreenshotFiles.kt
@@ -35,7 +35,7 @@ internal class ScreenshotFiles(
 
         val screenshotTestDirectory = directoryStorage.obtainDirectory(getDirectoryForTest(screenshotRootDirectory))
 
-        val screenshotName = System.currentTimeMillis().toString() + NAME_SEPARATOR + tag + EXTENSION
+        val screenshotName = tag + EXTENSION
         return screenshotTestDirectory.resolve(screenshotName)
     }
 


### PR DESCRIPTION
Screenshoter adds time to the name of the screenshot only for Screennshots implementation. Such behaviour was removed from DocLoc screenshooter.
close #24 