### PR TITLE
Feature/updated basetestcase

### DIFF
--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/api/testcase/BaseTestCase.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/api/testcase/BaseTestCase.kt
@@ -1,10 +1,15 @@
 package com.kaspersky.kaspresso.testcases.api.testcase
 
+import com.kaspersky.kaspresso.device.Device
+import com.kaspersky.kaspresso.device.server.AdbServer
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
+import com.kaspersky.kaspresso.logger.UiTestLogger
 import com.kaspersky.kaspresso.testcases.core.sections.AfterTestSection
 import com.kaspersky.kaspresso.testcases.core.sections.BeforeTestSection
 import com.kaspersky.kaspresso.testcases.core.sections.MainTestSection
 import com.kaspersky.kaspresso.testcases.core.sections.TransformSection
+import com.kaspersky.kaspresso.testcases.core.testassistants.TestAssistantsProvider
+import com.kaspersky.kaspresso.testcases.core.testassistants.TestAssistantsProviderImpl
 import com.kaspersky.kaspresso.testcases.core.testcontext.BaseTestContext
 import com.kaspersky.kaspresso.testcases.models.TestBody
 
@@ -19,10 +24,16 @@ import com.kaspersky.kaspresso.testcases.models.TestBody
 abstract class BaseTestCase<InitData, Data>(
     kaspressoBuilder: Kaspresso.Builder = Kaspresso.Builder.default(),
     private val dataProducer: (((InitData.() -> Unit)?) -> Data)
-) {
-    private val testCaseName = javaClass.simpleName
+) : TestAssistantsProvider {
 
     internal val kaspresso: Kaspresso = kaspressoBuilder.build()
+
+    private val testCaseName = javaClass.simpleName
+    private val testAssistantsProvider = TestAssistantsProviderImpl(kaspresso)
+
+    override val adbServer: AdbServer = testAssistantsProvider.adbServer
+    override val device: Device = testAssistantsProvider.device
+    override val testLogger: UiTestLogger = testAssistantsProvider.testLogger
 
     /**
      * Starts the building of a test, sets the [BeforeTestSection] actions and returns an existing instance of

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/api/testcase/BaseTestCase.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/api/testcase/BaseTestCase.kt
@@ -4,6 +4,7 @@ import com.kaspersky.kaspresso.device.Device
 import com.kaspersky.kaspresso.device.server.AdbServer
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.logger.UiTestLogger
+import com.kaspersky.kaspresso.testcases.core.TestRunner
 import com.kaspersky.kaspresso.testcases.core.sections.AfterTestSection
 import com.kaspersky.kaspresso.testcases.core.sections.BeforeTestSection
 import com.kaspersky.kaspresso.testcases.core.sections.MainTestSection
@@ -11,6 +12,7 @@ import com.kaspersky.kaspresso.testcases.core.sections.TransformSection
 import com.kaspersky.kaspresso.testcases.core.testassistants.TestAssistantsProvider
 import com.kaspersky.kaspresso.testcases.core.testassistants.TestAssistantsProviderImpl
 import com.kaspersky.kaspresso.testcases.core.testcontext.BaseTestContext
+import com.kaspersky.kaspresso.testcases.core.testcontext.TestContext
 import com.kaspersky.kaspresso.testcases.models.TestBody
 
 /**
@@ -71,6 +73,25 @@ abstract class BaseTestCase<InitData, Data>(
         }
 
         return MainTestSection(kaspresso, testBodyBuilder)
+    }
+
+    /**
+     * Runs:
+     * 1) [BeforeTestSection],
+     * 2) Optional [init],
+     * 3) Optional [TransformSection.transform]'s sections (only if [init] was called before),
+     * 4) [MainTestSection]'s steps,
+     * 5) [AfterTestSection]. [AfterTestSection] is invoked even if [BeforeTestSection] or [BaseTestCase]'s [steps] failed.
+     *
+     * @param steps steps to run.
+     */
+    fun run(
+        testName: String = testCaseName,
+        steps: TestContext<Data>.() -> Unit
+    ) {
+        val testBodyBuilder = createBaseTestBodyBuilder(testName)
+        val testBody = testBodyBuilder.apply { this.steps = steps }.build()
+        TestRunner<InitData, Data>(kaspresso).run(testBody)
     }
 
     private fun createBaseTestBodyBuilder(testName: String): TestBody.Builder<InitData, Data> {

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/api/testcase/BaseTestCase.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/api/testcase/BaseTestCase.kt
@@ -4,7 +4,6 @@ import com.kaspersky.kaspresso.device.Device
 import com.kaspersky.kaspresso.device.server.AdbServer
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.logger.UiTestLogger
-import com.kaspersky.kaspresso.testcases.core.TestRunner
 import com.kaspersky.kaspresso.testcases.core.sections.AfterTestSection
 import com.kaspersky.kaspresso.testcases.core.sections.BeforeTestSection
 import com.kaspersky.kaspresso.testcases.core.sections.MainTestSection
@@ -49,9 +48,7 @@ abstract class BaseTestCase<InitData, Data>(
         testName: String = testCaseName,
         actions: BaseTestContext.() -> Unit
     ): AfterTestSection<InitData, Data> {
-
         val testBodyBuilder = createBaseTestBodyBuilder(testName)
-
         return BeforeTestSection(kaspresso, testBodyBuilder).beforeTest(actions)
     }
 
@@ -71,27 +68,22 @@ abstract class BaseTestCase<InitData, Data>(
         val testBodyBuilder = createBaseTestBodyBuilder(testName).apply {
             initActions = actions
         }
-
         return MainTestSection(kaspresso, testBodyBuilder)
     }
 
     /**
-     * Runs:
-     * 1) [BeforeTestSection],
-     * 2) Optional [init],
-     * 3) Optional [TransformSection.transform]'s sections (only if [init] was called before),
-     * 4) [MainTestSection]'s steps,
-     * 5) [AfterTestSection]. [AfterTestSection] is invoked even if [BeforeTestSection] or [BaseTestCase]'s [steps] failed.
+     * Sets [com.kaspersky.kaspresso.testcases.core.sections.MainTestSection] steps, creates an instance of
+     * [MainTestSection] and runs it
      *
-     * @param steps steps to run.
+     * @param testName a name of the test.
+     * @param steps actions to invoke in main test section.
      */
-    fun run(
+    protected fun run(
         testName: String = testCaseName,
         steps: TestContext<Data>.() -> Unit
     ) {
         val testBodyBuilder = createBaseTestBodyBuilder(testName)
-        val testBody = testBodyBuilder.apply { this.steps = steps }.build()
-        TestRunner<InitData, Data>(kaspresso).run(testBody)
+        MainTestSection(kaspresso, testBodyBuilder).run(steps)
     }
 
     private fun createBaseTestBodyBuilder(testName: String): TestBody.Builder<InitData, Data> {

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/sections/InitSection.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/sections/InitSection.kt
@@ -7,7 +7,7 @@ interface InitSection<InitData, Data> {
 
     /**
      * Runs:
-     * 1) [BeforeTestSection],
+     * 1) Optional [BeforeTestSection],
      * 2) Optional [init],
      * 3) Optional [TransformSection.transform]'s sections (only if [init] was called before),
      * 4) [MainTestSection]'s steps,

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/sections/MainTestSection.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/sections/MainTestSection.kt
@@ -16,7 +16,7 @@ class MainTestSection<InitData, Data> internal constructor(
 
     /**
      * Runs:
-     * 1) [BeforeTestSection],
+     * 1) Optional [BeforeTestSection],
      * 2) Optional [init],
      * 3) Optional [transform]'s sections (only if [init] was called before),
      * 4) [MainTestSection]'s steps,

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/sections/TransformSection.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/sections/TransformSection.kt
@@ -7,7 +7,7 @@ interface TransformSection<Data> {
 
     /**
      * Runs:
-     * 1) [BeforeTestSection],
+     * 1) Optional [BeforeTestSection],
      * 2) Optional [InitSection.init],
      * 3) Optional [transform]'s sections (only if [InitSection.init] was called before),
      * 4) [MainTestSection]'s steps,

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/testassistants/TestAssistantsProvider.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/testassistants/TestAssistantsProvider.kt
@@ -8,7 +8,7 @@ import com.kaspersky.kaspresso.logger.UiTestLogger
  * Provider of test assistants allowed in [com.kaspersky.kaspresso.testcases.core.testcontext.BaseTestContext],
  * [com.kaspersky.kaspresso.testcases.api.testcase.BaseTestCase] and their inheritors
  */
-internal interface TestAssistantsProvider {
+interface TestAssistantsProvider {
 
     val device: Device
     val adbServer: AdbServer

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/testassistants/TestAssistantsProvider.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/testassistants/TestAssistantsProvider.kt
@@ -1,0 +1,16 @@
+package com.kaspersky.kaspresso.testcases.core.testassistants
+
+import com.kaspersky.kaspresso.device.Device
+import com.kaspersky.kaspresso.device.server.AdbServer
+import com.kaspersky.kaspresso.logger.UiTestLogger
+
+/**
+ * Provider of test assistants allowed in [com.kaspersky.kaspresso.testcases.core.testcontext.BaseTestContext],
+ * [com.kaspersky.kaspresso.testcases.api.testcase.BaseTestCase] and their inheritors
+ */
+internal interface TestAssistantsProvider {
+
+    val device: Device
+    val adbServer: AdbServer
+    val testLogger: UiTestLogger
+}

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/testassistants/TestAssistantsProviderImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/testassistants/TestAssistantsProviderImpl.kt
@@ -1,0 +1,13 @@
+package com.kaspersky.kaspresso.testcases.core.testassistants
+
+import com.kaspersky.kaspresso.device.Device
+import com.kaspersky.kaspresso.device.server.AdbServer
+import com.kaspersky.kaspresso.kaspresso.Kaspresso
+import com.kaspersky.kaspresso.logger.UiTestLogger
+
+internal class TestAssistantsProviderImpl(kaspresso: Kaspresso) : TestAssistantsProvider {
+
+    override val device: Device = kaspresso.device
+    override val adbServer: AdbServer = kaspresso.adbServer
+    override val testLogger: UiTestLogger = kaspresso.testLogger
+}

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/testcontext/BaseTestContext.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/testcontext/BaseTestContext.kt
@@ -12,6 +12,8 @@ import com.kaspersky.kaspresso.flakysafety.FlakySafetyProvider
 import com.kaspersky.kaspresso.flakysafety.FlakySafetyProviderImpl
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
 import com.kaspersky.kaspresso.logger.UiTestLogger
+import com.kaspersky.kaspresso.testcases.core.testassistants.TestAssistantsProvider
+import com.kaspersky.kaspresso.testcases.core.testassistants.TestAssistantsProviderImpl
 
 /**
  * Provides the Kaspresso functionality for "run" section: [Device], [AdbServer], the [UiTestLogger] implementation
@@ -23,9 +25,5 @@ open class BaseTestContext internal constructor(
 ) : FlakySafetyProvider by FlakySafetyProviderImpl(kaspresso.params.flakySafetyParams, kaspresso.libLogger),
     ContinuouslyProvider by ContinuouslyProviderImpl(kaspresso.params.continuouslyParams, kaspresso.libLogger),
     ComposeProvider by ComposeProviderImpl(kaspresso),
-    WebComposeProvider by WebComposeProviderImpl(kaspresso) {
-
-    val device: Device = kaspresso.device
-    val adbServer: AdbServer = kaspresso.adbServer
-    val testLogger: UiTestLogger = kaspresso.testLogger
-}
+    WebComposeProvider by WebComposeProviderImpl(kaspresso),
+    TestAssistantsProvider by TestAssistantsProviderImpl(kaspresso)

--- a/sample/src/androidTest/java/com/kaspersky/kaspressample/simple_tests/SimpleTest.kt
+++ b/sample/src/androidTest/java/com/kaspersky/kaspressample/simple_tests/SimpleTest.kt
@@ -34,13 +34,10 @@ class SimpleTest : TestCase() {
     val activityTestRule = ActivityTestRule(MainActivity::class.java, true, false)
 
     @Test
-    fun test() {
-        before {
-            activityTestRule.launchActivity(null)
-        }.after {
-        }.run {
-
+    fun test() =
+        run {
             step("Open Simple Screen") {
+                activityTestRule.launchActivity(null)
                 testLogger.i("I am testLogger")
                 device.screenshots.take("Additional_screenshot")
                 MainScreen {
@@ -79,6 +76,5 @@ class SimpleTest : TestCase() {
                     CheckEditScenario()
                 )
             }
-        }
     }
 }

--- a/sample/src/androidTest/java/com/kaspersky/kaspressample/simple_tests/SimpleTestWithRule.kt
+++ b/sample/src/androidTest/java/com/kaspersky/kaspressample/simple_tests/SimpleTestWithRule.kt
@@ -37,14 +37,11 @@ class SimpleTestWithRule {
     val testCaseRule = TestCaseRule(javaClass.simpleName)
 
     @Test
-    fun test() {
-        testCaseRule.before {
-            activityTestRule.launchActivity(null)
-        }.after {
-        }.run {
-
+    fun test() =
+        testCaseRule.run {
             step("Open Simple Screen") {
                 testLogger.i("I am testLogger")
+                activityTestRule.launchActivity(null)
                 device.screenshots.take("Additional_screenshot")
                 MainScreen {
                     simpleButton {
@@ -82,6 +79,5 @@ class SimpleTestWithRule {
                     CheckEditScenario()
                 )
             }
-        }
     }
 }

--- a/wiki/02. How to write autotests and appropriate test structure.md
+++ b/wiki/02. How to write autotests and appropriate test structure.md
@@ -251,35 +251,39 @@ Finally, let's look at all available Test DSL in Kaspresso:
 4. ```init-transform-run```
 5. ```init-transform-transform-run```. It's possible to add multiple *transform* blocks.
 6. ```init-run```
+7. ```run```
 
 #### Some words about *BaseTestContext* method
 You can notice an existing of some BaseTestContext in `before`, `after` and `run` methods. BaseTestContext gives you access to all Kaspresso's entities that a developer can need during the test. Also, BaseTestContext gives you insurance that all of these entities were created correctly for the current session and with actual Kaspresso configurator. <br>
 So, the next things are available in BaseTestContext:
 1. ```data``` <br>
 If you set your test data by ```init-transform``` methods using then this test data is available by a ```data``` field.
-2. ```testLogger``` <br>
-It's a logger for tests allowed to output logs by a more appropriate and readable form.
-3. ```device``` <br>
-An instance of ```Device``` class is available in this context. <br>
-It's a special interface given beautiful possibilities to do a lot of useful things at the test.
-Implementations of ```device``` use UiAutomator and AdbServer under the hood. <br>
-More detailed info about ```Device``` is [here](./03.%20Device.md)
-4. ```adbServer``` <br>
-You have access to AdbServer instance used in ```Device```'s interfaces via ```adbServer``` property.
-5. ```flakySafely``` <br>
+2. ```flakySafely``` <br>
 It's a method that receives a lambda and invokes it in the same manner as FlakySafeBehaviorInterceptors do.
 If you disable this interceptor or if you want to set some special flaky safety params for any view, you can use this method.
 The example is [here](../sample/src/androidTest/java/com/kaspersky/kaspressample/flaky_tests/CommonFlakyTest.kt).
-6. `continuously` <br>
+3. `continuously` <br>
 It's a method that receives a lambda and invokes it in the same manner as `ContinuouslyProviderImpl` does.
 It is similar to what `flakySafely` does, but for negative scenarios, where you need all the time to check that something does not happen.
 If you disable this interceptor or if you want to set some special check during params for any view, you can use this method.
 The example is [here](../sample/src/androidTest/java/com/kaspersky/kaspressample/flaky_tests/ContinuouslyTest.kt).
-7. ```compose``` <br>
+4. ```compose``` <br>
 This is a method to make a composed action from multiple actions or assertions, and this action succeeds if at least one of its components succeeds.
 It is available as an extension function for any KView (any that implements both BaseActions, BaseAssertions and Interceptable interfaces),
 and as just a regular method (in this case it can take actions on different views as well).
 The example is [here](../sample/src/androidTest/java/com/kaspersky/kaspressample/flaky_tests/ComposeTest.kt)
+5. ```testAssistants``` <br>
+Special assistants to write tests. Pay your attention to the fact that these assistants are available in ```BaseTestCase``` also.
+    1. ```testLogger``` <br>
+    It's a logger for tests allowed to output logs by a more appropriate and readable form.
+    2. ```device``` <br>
+    An instance of ```Device``` class is available in this context. <br>
+    It's a special interface given beautiful possibilities to do a lot of useful things at the test.
+    Implementations of ```device``` use UiAutomator and AdbServer under the hood. <br>
+    More detailed info about ```Device``` is [here](./03.%20Device.md)
+    3. ```adbServer``` <br>
+    You have access to AdbServer instance used in ```Device```'s interfaces via ```adbServer``` property.
+
 
 ### Examples
 You can look at examples of how to [use and configure Kaspresso](../sample/src/androidTest/java/com/kaspersky/kaspressample/configurator_tests)


### PR DESCRIPTION
1. In a test, you can start from ```run``` method immediately
2. Some properties located in ```BaseTestContext``` have been migrated to special ```TestAssistants``` that is available through ```BasetTestCase``` and ```BaseTestCaseRule```.
3. Updated documentation.

close https://github.com/KasperskyLab/Kaspresso/issues/26