### PR TITLE
Feature/steps propagation into shell for marathon

### DIFF
--- a/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/interceptors/watcher/testcase/impl/logging/LoggingStepWatcherInterceptor.kt
+++ b/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/interceptors/watcher/testcase/impl/logging/LoggingStepWatcherInterceptor.kt
@@ -75,6 +75,6 @@ class LoggingStepWatcherInterceptor(
     private fun getStepHeader(stepInfo: StepInfo): String {
         return "TEST STEP: \"" +
                 (stepInfo.number?.let { "$it. " } ?: "") +
-                "${stepInfo.description}\" in ${stepInfo.testClassName}"
+                "${stepInfo.description}\" in ${stepInfo.testIdentifier}"
     }
 }

--- a/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/interceptors/watcher/testcase/impl/screenshot/ScreenshotStepWatcherInterceptor.kt
+++ b/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/interceptors/watcher/testcase/impl/screenshot/ScreenshotStepWatcherInterceptor.kt
@@ -31,5 +31,5 @@ class ScreenshotStepWatcherInterceptor(
         screenshots.take("${makeScreenshotTag(stepInfo)}_failure_${error.javaClass.simpleName}")
     }
 
-    private fun makeScreenshotTag(stepInfo: StepInfo) = "${stepInfo.testClassName}_step_${stepInfo.ordinal}"
+    private fun makeScreenshotTag(stepInfo: StepInfo) = "${stepInfo.testIdentifier}_step_${stepInfo.ordinal}"
 }

--- a/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/report/impl/AllureReportWriter.kt
+++ b/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/report/impl/AllureReportWriter.kt
@@ -1,29 +1,18 @@
 package com.kaspersky.kaspresso.report.impl
 
 import com.google.gson.Gson
-import com.kaspersky.kaspresso.logger.UiTestLogger
 import com.kaspersky.kaspresso.report.ReportWriter
+import com.kaspersky.kaspresso.steps.StepsResultsConsumer
 import com.kaspersky.kaspresso.testcases.models.info.TestInfo
 
 /**
  * This [com.kaspersky.kaspresso.report.ReportWriter] processes [com.kaspersky.kaspresso.testcases.models.info.TestInfo]
- * for generating LogCat logs with <a href="https://docs.qameta.io/allure/#_steps">Allure's steps</a> info JSON.
- *
- * I/KASPRESSO: ---------------------------------------------------------------------------
- * I/KASPRESSO: TEST PASSED
- * I/KASPRESSO: ---------------------------------------------------------------------------
- * I/KASPRESSO: #AllureStepsInfoJson#: [{"attachments":[],"name":"My step 1","parameters":[],"stage":"finished","start":1568790287246,"status":"passed", "steps":[],"stop":1568790288184}]
- *
- * This logs should be processed by your's tests orchestrator (e.g. <a href="https://github.com/Malinskiy/marathon">Marathon</a>).
+ * for generating <a href="https://docs.qameta.io/allure/#_steps">Allure's steps</a> info JSON.
+ * After JSON generation it will be sent into special consumer which will propagate steps information further.
  */
 class AllureReportWriter(
-    private val uiTestLogger: UiTestLogger
+    private val stepsResultsConsumers: List<StepsResultsConsumer>
 ) : ReportWriter {
-
-    companion object {
-        private const val STEPS_INFO_LABEL = "#AllureStepsInfoJson#:"
-        private const val MAX_LOG_CHUNK_LENGTH = 4000 - STEPS_INFO_LABEL.length - 1
-    }
 
     private val stepInfoConverter: StepInfoConverter by lazy { StepInfoConverter() }
     private val gson: Gson by lazy { Gson() }
@@ -32,18 +21,6 @@ class AllureReportWriter(
         val steps = testInfo.stepInfos.map { stepInfoConverter.convert(it) }
         val stepsJson = gson.toJson(steps)
 
-        if (stepsJson.length > MAX_LOG_CHUNK_LENGTH) {
-            val chunkCount = stepsJson.length / MAX_LOG_CHUNK_LENGTH
-            for (i in 0..chunkCount) {
-                val max = MAX_LOG_CHUNK_LENGTH * (i + 1)
-                if (max >= stepsJson.length) {
-                    uiTestLogger.i("$STEPS_INFO_LABEL ${stepsJson.substring(MAX_LOG_CHUNK_LENGTH * i)}")
-                } else {
-                    uiTestLogger.i("$STEPS_INFO_LABEL ${stepsJson.substring(MAX_LOG_CHUNK_LENGTH * i, max)}")
-                }
-            }
-        } else {
-            uiTestLogger.i("$STEPS_INFO_LABEL $stepsJson")
-        }
+        stepsResultsConsumers.forEach { it.consume(testInfo.testIdentifier, stepsJson) }
     }
 }

--- a/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/steps/StepsResultsConsumer.kt
+++ b/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/steps/StepsResultsConsumer.kt
@@ -1,0 +1,14 @@
+package com.kaspersky.kaspresso.steps
+
+import com.kaspersky.kaspresso.testcases.models.TestIdentifier
+
+/**
+ * Interface for consumers of steps results information.
+ */
+interface StepsResultsConsumer {
+
+    /**
+     * Method to send information about steps in JSON format into consumer to propagate it further correctly.
+     */
+    fun consume(testIdentifier: TestIdentifier, stepsResultsJson: String)
+}

--- a/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/steps/StepsResultsConsumerImpl.kt
+++ b/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/steps/StepsResultsConsumerImpl.kt
@@ -1,0 +1,98 @@
+package com.kaspersky.kaspresso.steps
+
+import android.os.Bundle
+import androidx.test.internal.runner.listener.InstrumentationResultPrinter.*
+import androidx.test.platform.app.InstrumentationRegistry
+import com.kaspersky.kaspresso.logger.UiTestLogger
+import com.kaspersky.kaspresso.logger.UiTestLoggerImpl
+import com.kaspersky.kaspresso.testcases.models.TestIdentifier
+import com.kaspersky.kaspresso.testcases.models.extensions.toTestIdentifier
+import org.junit.AssumptionViolatedException
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import java.io.PrintWriter
+import java.io.StringWriter
+
+/**
+ * This [org.junit.rules.TestWatcher] writes information about test steps into adb shell's output
+ * through [android.app.Instrumentation.sendStatus] when test ends with success or failure.
+ * When we writes unknown test events into adb shell's output they will be parsed by ddmlib as
+ * <a href="https://android.googlesource.com/platform/tools/base/+/master/ddmlib/src/main/java/com/android/ddmlib/testrunner/InstrumentationResultParser.java#358">testMetrics</a> field.
+ *
+ * This testMetrics should be processed by your's tests orchestrator (e.g. <a href="https://github.com/Malinskiy/marathon">Marathon</a>).
+ */
+class StepsResultsConsumerImpl(
+    private val logger: UiTestLogger = UiTestLoggerImpl(LOG_TAG)
+) : TestWatcher(), StepsResultsConsumer {
+
+    companion object {
+        private const val LOG_TAG = "StepsResultsConsumerImpl"
+
+        private const val INSTRUMENTATION_KEY_STEPS_RESULTS_JSON = "marathon.stepsResultsJson"
+        private const val EMPTY_STEPS_RESULTS_JSON = "[]"
+
+        // copied from InstrumentationResultPrinter.MAX_TRACE_SIZE
+        private const val MAX_TRACE_SIZE = 32 * 1024
+    }
+
+    private var stepsResultsJson = EMPTY_STEPS_RESULTS_JSON
+
+    override fun consume(testIdentifier: TestIdentifier, stepsResultsJson: String) {
+        logger.d("Consume steps JSON from test [$testIdentifier]")
+        this.stepsResultsJson = stepsResultsJson
+    }
+
+    override fun failed(e: Throwable, description: Description) {
+        super.failed(e, description)
+
+        logTestStatus(description, "failed")
+        sendStatus(REPORT_VALUE_RESULT_FAILURE, description, e)
+    }
+
+    override fun skipped(e: AssumptionViolatedException, description: Description) {
+        super.skipped(e, description)
+
+        logTestStatus(description, "skipped")
+        sendStatus(REPORT_VALUE_RESULT_ASSUMPTION_FAILURE, description, e)
+    }
+
+    override fun succeeded(description: Description) {
+        super.succeeded(description)
+
+        logTestStatus(description, "succeeded")
+        sendStatus(REPORT_VALUE_RESULT_OK, description)
+    }
+
+    private fun sendStatus(code: Int, description: Description, throwable: Throwable? = null) {
+        InstrumentationRegistry.getInstrumentation()
+            .sendStatus(code, createBundle(description, stepsResultsJson, throwable))
+    }
+
+    private fun createBundle(
+        description: Description,
+        stepsResultsJson: String,
+        throwable: Throwable?
+    ): Bundle {
+        return Bundle().apply {
+            putString(REPORT_KEY_NAME_CLASS, description.className)
+            putString(REPORT_KEY_NAME_TEST, description.methodName)
+            putInt(REPORT_KEY_NUM_TOTAL, description.testCount())
+            throwable?.let { putString(REPORT_KEY_STACK, throwable.getTrace()) }
+            putString(INSTRUMENTATION_KEY_STEPS_RESULTS_JSON, stepsResultsJson)
+        }
+    }
+
+    private fun logTestStatus(description: Description, message: String) {
+        val isStepsJsonEmpty = stepsResultsJson == EMPTY_STEPS_RESULTS_JSON
+        logger.d("Test [${description.toTestIdentifier()}] $message. Is steps JSON empty: $isStepsJsonEmpty")
+    }
+
+    private fun Throwable.getTrace(): String {
+        val stringWriter = StringWriter()
+        val writer = PrintWriter(stringWriter)
+        printStackTrace(writer)
+        val trace = stringWriter.toString()
+
+        return trace.takeIf { it.length < MAX_TRACE_SIZE } ?: trace.substring(0, MAX_TRACE_SIZE)
+    }
+}

--- a/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/testcases/api/testcase/DocLocScreenshotTestCase.kt
+++ b/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/testcases/api/testcase/DocLocScreenshotTestCase.kt
@@ -91,17 +91,19 @@ abstract class DocLocScreenshotTestCase(
     private lateinit var screenshotCapturer: DocLocScreenshotCapturer
 
     @PublishedApi
-    internal val logger: UiTestLogger = kaspresso.libLogger
+    internal val logger: UiTestLogger by lazy { kaspresso.libLogger }
 
-    private val confLocales: Locales = Locales(logger)
+    private val confLocales: Locales by lazy { Locales(logger) }
 
     @get:Rule
-    val localeRule = LocaleRule(
-        locales = locales?.let { confLocales.parseLocales(it) } ?: confLocales.getSupportedLocales(),
-        changeSystemLocale = changeSystemLocale,
-        device = kaspresso.device,
-        logger = kaspresso.libLogger
-    )
+    val localeRule by lazy {
+        LocaleRule(
+            locales = locales?.let { confLocales.parseLocales(it) } ?: confLocales.getSupportedLocales(),
+            changeSystemLocale = changeSystemLocale,
+            device = kaspresso.device,
+            logger = kaspresso.libLogger
+        )
+    }
 
     @get:Rule
     val storagePermissionRule = GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE)!!

--- a/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/TestRunner.kt
+++ b/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/TestRunner.kt
@@ -38,8 +38,8 @@ internal class TestRunner<InitData, Data>(
                 exceptions
             )
 
-        val stepsManager = StepsManager(testBody.testName, kaspresso.params.stepParams)
-        var testInfo = TestInfo(testBody.testName)
+        val stepsManager = StepsManager(kaspresso.testIdentifier, kaspresso.params.stepParams)
+        var testInfo = TestInfo(kaspresso.testIdentifier)
         var testPassed = true
 
         try {

--- a/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/step/StepsManager.kt
+++ b/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/step/StepsManager.kt
@@ -2,6 +2,7 @@ package com.kaspersky.kaspresso.testcases.core.step
 
 import com.kaspersky.kaspresso.params.StepParams
 import com.kaspersky.kaspresso.testcases.models.StepStatus
+import com.kaspersky.kaspresso.testcases.models.TestIdentifier
 import com.kaspersky.kaspresso.testcases.models.info.InternalStepInfo
 import com.kaspersky.kaspresso.testcases.models.info.StepInfo
 
@@ -59,7 +60,7 @@ import com.kaspersky.kaspresso.testcases.models.info.StepInfo
  */
 
 internal class StepsManager(
-    private val testName: String,
+    private val testIdentifier: TestIdentifier,
     private val stepParams: StepParams
 ) : StepInfoProducer {
 
@@ -170,7 +171,7 @@ internal class StepsManager(
 
         return InternalStepInfo(
             description = description,
-            testClassName = testName,
+            testIdentifier = testIdentifier,
             number = stepNumber?.joinToString(separator = "."),
             ordinal = ++stepsCounter,
             stepNumber = stepNumber,

--- a/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/testcases/models/TestIdentifier.kt
+++ b/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/testcases/models/TestIdentifier.kt
@@ -1,0 +1,14 @@
+package com.kaspersky.kaspresso.testcases.models
+
+/**
+ * Unique test identifier which consists of two parameters: class name with specifying package name + test method name.
+ */
+data class TestIdentifier(
+    val className: String,
+    val methodName: String
+) {
+
+    override fun toString(): String {
+        return "className: $className, methodName: $methodName"
+    }
+}

--- a/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/testcases/models/extensions/DescriptionExt.kt
+++ b/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/testcases/models/extensions/DescriptionExt.kt
@@ -1,0 +1,8 @@
+package com.kaspersky.kaspresso.testcases.models.extensions
+
+
+import com.kaspersky.kaspresso.testcases.models.TestIdentifier
+import org.junit.runner.Description
+
+
+fun Description.toTestIdentifier() = TestIdentifier(className, methodName)

--- a/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/testcases/models/info/InternalStepInfo.kt
+++ b/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/testcases/models/info/InternalStepInfo.kt
@@ -1,10 +1,11 @@
 package com.kaspersky.kaspresso.testcases.models.info
 
 import com.kaspersky.kaspresso.testcases.models.StepStatus
+import com.kaspersky.kaspresso.testcases.models.TestIdentifier
 
 internal class InternalStepInfo(
     override val description: String,
-    override val testClassName: String,
+    override val testIdentifier: TestIdentifier,
     override val number: String?,
     override val ordinal: Int,
     override val startTime: Long,
@@ -33,7 +34,7 @@ internal class InternalStepInfo(
     override fun toString(): String {
         return "StepInfo(" +
                 "description=$description, " +
-                "testClassName=$testClassName, " +
+                "testIdentifier=$testIdentifier, " +
                 "number=$number, " +
                 "ordinal=$ordinal, " +
                 "stepNumber=$stepNumber, " +

--- a/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/testcases/models/info/StepInfo.kt
+++ b/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/testcases/models/info/StepInfo.kt
@@ -1,10 +1,11 @@
 package com.kaspersky.kaspresso.testcases.models.info
 
 import com.kaspersky.kaspresso.testcases.models.StepStatus
+import com.kaspersky.kaspresso.testcases.models.TestIdentifier
 
 interface StepInfo {
     val description: String
-    val testClassName: String
+    val testIdentifier: TestIdentifier
     val number: String?
     val ordinal: Int
     val subSteps: List<StepInfo>

--- a/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/testcases/models/info/TestInfo.kt
+++ b/kaspresso/kaspresso-framework/src/main/kotlin/com/kaspersky/kaspresso/testcases/models/info/TestInfo.kt
@@ -1,7 +1,9 @@
 package com.kaspersky.kaspresso.testcases.models.info
 
+import com.kaspersky.kaspresso.testcases.models.TestIdentifier
+
 data class TestInfo internal constructor(
-    val testName: String,
+    val testIdentifier: TestIdentifier,
     val stepInfos: List<StepInfo> = listOf(),
     val throwable: Throwable? = null
 )

--- a/kaspresso/kaspresso-sample/src/androidTest/java/com/kaspersky/kaspressample/configurator_tests/enricher_tests/enrichers/AssertionMainSectionEnricher.kt
+++ b/kaspresso/kaspresso-sample/src/androidTest/java/com/kaspersky/kaspressample/configurator_tests/enricher_tests/enrichers/AssertionMainSectionEnricher.kt
@@ -8,7 +8,7 @@ import com.kaspersky.kaspresso.testcases.models.info.TestInfo
 class AssertionMainSectionEnricher : MainSectionEnricher<EnricherTestData> {
 
     override fun TestContext<EnricherTestData>.afterMainSectionRun(testInfo: TestInfo) {
-        step("Real step after 'run' block --> assert posts count | ${testInfo.testName}") {
+        step("Real step after 'run' block --> assert posts count | ${testInfo.testIdentifier}") {
             assert(data.posts.size == 2)
         }
     }

--- a/kaspresso/kaspresso-sample/src/androidTest/java/com/kaspersky/kaspressample/configurator_tests/enricher_tests/enrichers/LoggingMainSectionEnricher.kt
+++ b/kaspresso/kaspresso-sample/src/androidTest/java/com/kaspersky/kaspressample/configurator_tests/enricher_tests/enrichers/LoggingMainSectionEnricher.kt
@@ -8,12 +8,12 @@ import com.kaspersky.kaspresso.testcases.models.info.TestInfo
 class LoggingMainSectionEnricher : MainSectionEnricher<EnricherTestData> {
 
     override fun TestContext<EnricherTestData>.beforeMainSectionRun(testInfo: TestInfo) {
-        testLogger.d("Before main section run... | ${testInfo.testName}")
+        testLogger.d("Before main section run... | ${testInfo.testIdentifier}")
         testLogger.d("Check users count: ${data.users.size}")
     }
 
     override fun TestContext<EnricherTestData>.afterMainSectionRun(testInfo: TestInfo) {
-        testLogger.d("After main section run... | ${testInfo.testName}")
+        testLogger.d("After main section run... | ${testInfo.testIdentifier}")
         testLogger.d("Check posts count: ${data.posts.size}")
     }
 }

--- a/kaspresso/kaspresso-sample/src/androidTest/java/com/kaspersky/kaspressample/device_tests/DeviceLanguageSampleTest.kt
+++ b/kaspresso/kaspresso-sample/src/androidTest/java/com/kaspersky/kaspressample/device_tests/DeviceLanguageSampleTest.kt
@@ -6,9 +6,9 @@ import androidx.test.rule.GrantPermissionRule
 import com.kaspersky.kaspressample.MainActivity
 import com.kaspersky.kaspressample.screen.MainScreen
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
-import java.util.Locale
 import org.junit.Rule
 import org.junit.Test
+import java.util.*
 
 class DeviceLanguageSampleTest : TestCase() {
 


### PR DESCRIPTION
Всем привет.
Создаю PR, чтобы наконец-то затащить наш hh-шный способ проброса step-ов в Marathon из Kaspresso. 

Что я сделал: чтобы корректно отловить сигналы об окончании теста и пробросить какие-то данные, я отправляю сигналы в Marathon через ddmlib. Для этого я создал специальный TestWatcher, который:
а) слушает события success / failed / skipped 
б) при наступлении этих событий отправляет специальный INSTRUMENTATION_STATUS с прикрепленным JSON-ом от step-ов

В Marathon-е мы ловим эти сигналы и трансформируем их в step-ы Allure-а (ссылочка на наш hh-форк и нужную ветку для запуска тестов -- https://github.com/hhru/marathon/tree/fork_develop) 

Чтобы пробросить такие сигналы, чтобы пробросить JSON, мне пришлось сделать инициализацию Kaspresso отложенной, сделать объект kaspresso как lateinit var, чтобы я мог его инициализировать в другом TestWatcher-е в методе starting. Это мне нужно для корректного получения идентификатора теста, который есть в модели Description.

Дальше дело техники. Я пробрасываю повсюду вместо testName-а идентификатор теста, а в конце теста, когда Kaspresso завершает тест, он пробрасывает сформированный JSON в мой test watcher. 

Реализация, в целом, работает нормально, за исключением двух пунктов. Одного важного, второго - не очень.


1. Не проходят тесты-наследники DocLocScreenshotTestCase
— важный пункт.
Не понимаю, как пофиксить. 

В этом TestCase-е есть тестовый rule, которому при инициализации нужен объект класса Kaspresso, который будет сформирован чуть позже =/ Не знаю, что с этим делать пока что =(
В hh не словили эту штуку, потому что не пользовались.

2. Когда ты запустишь марафон на тестах, ты увидишь, что у тебя каждый тест как будто завершается дважды. Это происходит как раз из-за того, что я отправляю "уточняющий" INSTRUMENTATION_STATUS через ddmlib. Жить не мешает, но с толку может сбить. Из-за этого в логах марафона ты можешь увидеть, что процесс выполнения тестов > 100%, в аллюровских репортах дважды прикрепляются файлы с логами. 

Тут надо просто сидеть и дорабатывать марафон, но мы в hh как-то уже свыклись с этим и нам это не мешает. 