### PR TITLE
#issue242 add robolectric support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,9 +18,13 @@ espressoCore = { module = "androidx.test.espresso:espresso-core", version.ref = 
 espressoWeb = { module = "androidx.test.espresso:espresso-web", version.ref = "espresso" }
 testCore = "androidx.test:core:1.3.0"
 uiAutomator = "androidx.test.uiautomator:uiautomator:2.2.0"
+fragmentTesting = "androidx.fragment:fragment-testing:1.3.2"
+robolectric = "org.robolectric:robolectric:4.5.1"
 
 androidXCore = "androidx.core:core:1.3.1"
 androidXRules = "androidx.test:rules:1.3.0"
+androidXTest = "androidx.test.ext:junit:1.1.2"
+androidXTestKtx = "androidx.test.ext:junit-ktx:1.1.2"
 
 appcompat = "androidx.appcompat:appcompat:1.2.0"
 material = "com.google.android.material:material:1.2.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,12 +21,12 @@ uiAutomator = "androidx.test.uiautomator:uiautomator:2.2.0"
 fragmentTesting = "androidx.fragment:fragment-testing:1.3.2"
 robolectric = "org.robolectric:robolectric:4.5.1"
 
-androidXCore = "androidx.core:core:1.3.1"
+androidXCore = "androidx.core:core:1.3.0"
 androidXRules = "androidx.test:rules:1.3.0"
 androidXTest = "androidx.test.ext:junit:1.1.2"
 androidXTestKtx = "androidx.test.ext:junit-ktx:1.1.2"
 
-appcompat = "androidx.appcompat:appcompat:1.2.0"
+appcompat = "androidx.appcompat:appcompat:1.3.0"
 material = "com.google.android.material:material:1.2.0"
 constraint = "androidx.constraintlayout:constraintlayout:2.0.0"
 

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/docloc/MetadataSaver.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/docloc/MetadataSaver.kt
@@ -9,22 +9,24 @@ import com.kaspersky.kaspresso.logger.UiTestLogger
 import java.io.File
 
 internal class MetadataSaver(
-    private val activities: Activities,
-    private val apps: Apps,
+    private val activities: Activities?,
+    private val apps: Apps?,
     private val logger: UiTestLogger
 ) {
     private val activityMetadata = ActivityMetadata(logger)
 
     fun saveScreenshotMetadata(folderPath: File, name: String) {
-        val activity = activities.getResumed()
+        val activity = activities?.getResumed()
         if (activity == null) {
             logger.e("Activity is null when saving metadata $name")
             return
         }
         runCatching {
-            val metadata = activityMetadata.getFromActivity(activity)
-                .toXml(apps.targetAppPackageName)
-            folderPath.resolve("$name.xml").safeWrite(logger, metadata)
+            apps?.run {
+                val metadata = activityMetadata.getFromActivity(activity)
+                    .toXml(apps.targetAppPackageName)
+                folderPath.resolve("$name.xml").safeWrite(logger, metadata)
+            }
         }
     }
 }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/docloc/SystemLanguage.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/docloc/SystemLanguage.kt
@@ -11,9 +11,9 @@ import com.kaspersky.kaspresso.logger.UiTestLogger
 import java.util.Locale
 
 internal class SystemLanguage(
-    private val context: Context,
+    private val context: Context?,
     private val logger: UiTestLogger,
-    private val hackPermissions: HackPermissions
+    private val hackPermissions: HackPermissions?
 ) {
 
     /**
@@ -46,12 +46,12 @@ internal class SystemLanguage(
      * @throws DocLocException In case of a failure to grant one
      */
     private fun grantPermissionsIfNeed() {
-        val permissionStateAtTheBeginning = context.checkPermission(Manifest.permission.CHANGE_CONFIGURATION, Process.myPid(), Process.myUid())
+        val permissionStateAtTheBeginning = context?.checkPermission(Manifest.permission.CHANGE_CONFIGURATION, Process.myPid(), Process.myUid())
         if (permissionStateAtTheBeginning == PackageManager.PERMISSION_GRANTED) {
             return
         }
-        val attemptToGrantPermissionResult = hackPermissions.grant(context.packageName, Manifest.permission.CHANGE_CONFIGURATION)
-        if (!attemptToGrantPermissionResult) {
+        val attemptToGrantPermissionResult = hackPermissions?.grant(context?.packageName.orEmpty(), Manifest.permission.CHANGE_CONFIGURATION)
+        if (attemptToGrantPermissionResult == false) {
             throw DocLocException(
                 "SystemLanguage: The attempt to grant Manifest.permission.CHANGE_CONFIGURATION for SystemLanguage failed"
             )

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/docloc/rule/LocaleRule.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/docloc/rule/LocaleRule.kt
@@ -13,13 +13,13 @@ import org.junit.runners.model.Statement
  */
 class LocaleRule internal constructor(
     private val locales: Set<Locale>,
-    private val device: Device,
+    private val device: Device?,
     private val changeSystemLocale: Boolean,
     private val logger: UiTestLogger
 ) : TestRule {
 
     private val systemLanguage: SystemLanguage =
-        SystemLanguage(device.targetContext, logger, device.hackPermissions)
+        SystemLanguage(device?.targetContext, logger, device?.hackPermissions)
 
     private val deviceLocale: Locale = Locale.getDefault()
     private var currentLocale: Locale? = null
@@ -42,14 +42,14 @@ class LocaleRule internal constructor(
             locales.onEach { locale ->
                 currentLocale = locale
                 logger.i("DocLoc: changeLanguageInApp is processing. New language=$locale is installing")
-                device.language.switchInApp(locale)
+                device?.language?.switchInApp(locale)
                 logger.i("DocLoc: changeLanguageInApp is processing. New language=$locale is installed")
                 base.evaluate()
             }
         } finally {
             logger.i("DocLoc: changeLanguageInApp is finishing. Device language=$deviceLocale is restoring")
             currentLocale = deviceLocale
-            device.language.switchInApp(deviceLocale)
+            device?.language?.switchInApp(deviceLocale)
             logger.i("DocLoc: changeLanguageInApp is finishing. Device language=$deviceLocale is restored")
         }
     }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/kaspresso/Kaspresso.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/kaspresso/Kaspresso.kt
@@ -1,72 +1,32 @@
 package com.kaspersky.kaspresso.kaspresso
 
-import android.app.Instrumentation
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.FailureHandler
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.Configurator
 import androidx.test.uiautomator.UiDevice
-import io.github.kakaocup.kakao.Kakao
-import com.kaspersky.adbserver.common.log.logger.LogLevel
-import com.kaspersky.components.kautomator.intercept.interaction.UiDeviceInteraction
-import com.kaspersky.components.kautomator.intercept.interaction.UiObjectInteraction
 import com.kaspersky.kaspresso.device.Device
 import com.kaspersky.kaspresso.device.accessibility.Accessibility
-import com.kaspersky.kaspresso.device.accessibility.AccessibilityImpl
 import com.kaspersky.kaspresso.device.activities.Activities
-import com.kaspersky.kaspresso.device.activities.ActivitiesImpl
 import com.kaspersky.kaspresso.device.apps.Apps
-import com.kaspersky.kaspresso.device.apps.AppsImpl
 import com.kaspersky.kaspresso.device.exploit.Exploit
-import com.kaspersky.kaspresso.device.exploit.ExploitImpl
 import com.kaspersky.kaspresso.device.files.Files
-import com.kaspersky.kaspresso.device.files.FilesImpl
 import com.kaspersky.kaspresso.device.keyboard.Keyboard
-import com.kaspersky.kaspresso.device.keyboard.KeyboardImpl
 import com.kaspersky.kaspresso.device.languages.Language
-import com.kaspersky.kaspresso.device.languages.LanguageImpl
 import com.kaspersky.kaspresso.device.location.Location
-import com.kaspersky.kaspresso.device.location.LocationImpl
 import com.kaspersky.kaspresso.device.logcat.Logcat
-import com.kaspersky.kaspresso.device.logcat.LogcatImpl
 import com.kaspersky.kaspresso.device.network.Network
-import com.kaspersky.kaspresso.device.network.NetworkImpl
 import com.kaspersky.kaspresso.device.permissions.HackPermissions
-import com.kaspersky.kaspresso.device.permissions.HackPermissionsImpl
 import com.kaspersky.kaspresso.device.permissions.Permissions
-import com.kaspersky.kaspresso.device.permissions.PermissionsImpl
 import com.kaspersky.kaspresso.device.phone.Phone
-import com.kaspersky.kaspresso.device.phone.PhoneImpl
 import com.kaspersky.kaspresso.device.screenshots.Screenshots
-import com.kaspersky.kaspresso.device.screenshots.ScreenshotsImpl
-import com.kaspersky.kaspresso.device.screenshots.screenshotfiles.DefaultScreenshotDirectoryProvider
-import com.kaspersky.kaspresso.device.screenshots.screenshotfiles.DefaultScreenshotNameProvider
-import com.kaspersky.kaspresso.device.screenshots.screenshotmaker.CombinedScreenshotMaker
-import com.kaspersky.kaspresso.device.screenshots.screenshotmaker.ExternalScreenshotMaker
-import com.kaspersky.kaspresso.device.screenshots.screenshotmaker.InternalScreenshotMaker
 import com.kaspersky.kaspresso.device.server.AdbServer
-import com.kaspersky.kaspresso.device.server.AdbServerImpl
 import com.kaspersky.kaspresso.failure.LoggingFailureHandler
 import com.kaspersky.kaspresso.idlewaiting.KautomatorWaitForIdleSettings
 import com.kaspersky.kaspresso.interceptors.behavior.DataBehaviorInterceptor
 import com.kaspersky.kaspresso.interceptors.behavior.ViewBehaviorInterceptor
 import com.kaspersky.kaspresso.interceptors.behavior.WebBehaviorInterceptor
-import com.kaspersky.kaspresso.interceptors.behavior.impl.autoscroll.AutoScrollViewBehaviorInterceptor
-import com.kaspersky.kaspresso.interceptors.behavior.impl.autoscroll.AutoScrollWebBehaviorInterceptor
-import com.kaspersky.kaspresso.interceptors.behavior.impl.flakysafety.FlakySafeDataBehaviorInterceptor
-import com.kaspersky.kaspresso.interceptors.behavior.impl.flakysafety.FlakySafeViewBehaviorInterceptor
-import com.kaspersky.kaspresso.interceptors.behavior.impl.flakysafety.FlakySafeWebBehaviorInterceptor
-import com.kaspersky.kaspresso.interceptors.behavior.impl.systemsafety.SystemDialogSafetyDataBehaviorInterceptor
-import com.kaspersky.kaspresso.interceptors.behavior.impl.systemsafety.SystemDialogSafetyViewBehaviorInterceptor
-import com.kaspersky.kaspresso.interceptors.behavior.impl.systemsafety.SystemDialogSafetyWebBehaviorInterceptor
 import com.kaspersky.kaspresso.interceptors.behaviorkautomator.DeviceBehaviorInterceptor
 import com.kaspersky.kaspresso.interceptors.behaviorkautomator.ObjectBehaviorInterceptor
-import com.kaspersky.kaspresso.interceptors.behaviorkautomator.impl.autoscroll.AutoScrollObjectBehaviorInterceptor
-import com.kaspersky.kaspresso.interceptors.behaviorkautomator.impl.flakysafety.FlakySafeDeviceBehaviorInterceptor
-import com.kaspersky.kaspresso.interceptors.behaviorkautomator.impl.flakysafety.FlakySafeObjectBehaviorInterceptor
-import com.kaspersky.kaspresso.interceptors.behaviorkautomator.impl.loader.UiObjectLoaderBehaviorInterceptor
-import com.kaspersky.kaspresso.interceptors.behaviorkautomator.impl.systemsafety.SystemDialogSafetyDeviceBehaviorInterceptor
-import com.kaspersky.kaspresso.interceptors.behaviorkautomator.impl.systemsafety.SystemDialogSafetyObjectBehaviorInterceptor
 import com.kaspersky.kaspresso.interceptors.tolibrary.LibraryInterceptorsInjector.injectKaspressoInKakao
 import com.kaspersky.kaspresso.interceptors.tolibrary.LibraryInterceptorsInjector.injectKaspressoInKautomator
 import com.kaspersky.kaspresso.interceptors.tolibrary.kautomator.KautomatorDeviceInterceptor
@@ -93,13 +53,10 @@ import com.kaspersky.kaspresso.interceptors.watcher.view.impl.logging.LoggingVie
 import com.kaspersky.kaspresso.interceptors.watcher.view.impl.logging.LoggingWebAssertionWatcherInterceptor
 import com.kaspersky.kaspresso.logger.UiTestLogger
 import com.kaspersky.kaspresso.logger.UiTestLoggerImpl
-import com.kaspersky.kaspresso.params.AutoScrollParams
-import com.kaspersky.kaspresso.params.ContinuouslyParams
-import com.kaspersky.kaspresso.params.FlakySafetyParams
-import com.kaspersky.kaspresso.params.Params
-import com.kaspersky.kaspresso.params.StepParams
+import com.kaspersky.kaspresso.params.*
 import com.kaspersky.kaspresso.report.impl.AllureReportWriter
 import com.kaspersky.kaspresso.testcases.core.testcontext.BaseTestContext
+import io.github.kakaocup.kakao.Kakao
 
 /**
  * The storage of all Kaspresso preferences and entities, such as [AdbServer], [Device] and different interceptors.
@@ -107,22 +64,24 @@ import com.kaspersky.kaspresso.testcases.core.testcontext.BaseTestContext
 data class Kaspresso(
     internal val libLogger: UiTestLogger,
     internal val testLogger: UiTestLogger,
-    internal val adbServer: AdbServer,
-    internal val device: Device,
     internal val params: Params,
     internal val viewActionWatcherInterceptors: List<ViewActionWatcherInterceptor>,
     internal val viewAssertionWatcherInterceptors: List<ViewAssertionWatcherInterceptor>,
     internal val atomWatcherInterceptors: List<AtomWatcherInterceptor>,
     internal val webAssertionWatcherInterceptors: List<WebAssertionWatcherInterceptor>,
-    internal val objectWatcherInterceptors: List<ObjectWatcherInterceptor>,
-    internal val deviceWatcherInterceptors: List<DeviceWatcherInterceptor>,
     internal val viewBehaviorInterceptors: List<ViewBehaviorInterceptor>,
     internal val dataBehaviorInterceptors: List<DataBehaviorInterceptor>,
     internal val webBehaviorInterceptors: List<WebBehaviorInterceptor>,
+    internal val stepWatcherInterceptors: List<StepWatcherInterceptor>,
+    internal val testRunWatcherInterceptors: List<TestRunWatcherInterceptor>,
+
+    //Kautomator dependent
+    internal val adbServer: AdbServer,
+    internal val device: Device?,
+    internal val objectWatcherInterceptors: List<ObjectWatcherInterceptor>,
+    internal val deviceWatcherInterceptors: List<DeviceWatcherInterceptor>,
     internal val objectBehaviorInterceptors: List<ObjectBehaviorInterceptor>,
     internal val deviceBehaviorInterceptors: List<DeviceBehaviorInterceptor>,
-    internal val stepWatcherInterceptors: List<StepWatcherInterceptor>,
-    internal val testRunWatcherInterceptors: List<TestRunWatcherInterceptor>
 ) {
 
     companion object {
@@ -174,7 +133,7 @@ data class Kaspresso(
              * @return the new instance of [Builder].
              */
             @Deprecated("Use `advanced()` builder.", ReplaceWith("Kaspresso.Builder.advanced(customize)"))
-            fun default(customize: Builder.() -> Unit = {}): Builder = advanced(customize)
+            fun default(sharedTest: Boolean = false, customize: Builder.() -> Unit = {}): Builder = advanced(sharedTest, customize)
 
             /**
              * Simple (preconfigured with logging and flaky-safe features) [Builder] for test environment configuration.
@@ -211,9 +170,10 @@ data class Kaspresso(
              *
              * @return the new instance of [Builder].
              */
-            fun simple(customize: Builder.() -> Unit = {}): Builder {
+            fun simple(sharedTest: Boolean = false, customize: Builder.() -> Unit = {}): Builder {
                 return Builder().apply {
 
+                    kautomatorConfig = KautomatorConfigResolver.build(sharedTest)
                     customize.invoke(this)
                     postInitVariables()
                     postDefaultInitInterceptors()
@@ -257,8 +217,9 @@ data class Kaspresso(
              *
              * @return the new instance of [Builder].
              */
-            fun advanced(customize: Builder.() -> Unit = {}): Builder {
-                return simple(customize).apply {
+            fun advanced(sharedTest: Boolean = false, customize: Builder.() -> Unit = {}): Builder {
+                return simple(sharedTest, customize).apply {
+                    kautomatorConfig = KautomatorConfigResolver.build(sharedTest)
                     stepWatcherInterceptors.add(ScreenshotStepWatcherInterceptor(screenshots))
                     testRunWatcherInterceptors.add(
                         TestRunnerScreenshotWatcherInterceptor(
@@ -281,61 +242,6 @@ data class Kaspresso(
          */
         lateinit var libLogger: UiTestLogger
 
-        /**
-         * Holds an implementation of [UiTestLogger] interface for external developer's usage in tests.
-         * If it was not specified, the default implementation with default tag is used.
-         */
-        lateinit var testLogger: UiTestLogger
-
-        /**
-         * Holds an instance of [Instrumentation] class.
-         * The public access was set up just for more convenient way to use.
-         * For example, in [Builder] you can use `instrumentation.targetContext` instead of `InstrumentationRegistry.getInstrumentation().targetContext`
-         */
-        val instrumentation: Instrumentation = InstrumentationRegistry.getInstrumentation()
-
-        private val uiDevice = UiDevice.getInstance(instrumentation)
-        private val configurator = Configurator.getInstance()
-
-        /**
-         * Holds an implementation of [AdbServer] interface. If it was not specified, the default implementation is used.
-         */
-        lateinit var adbServer: AdbServer
-
-        /**
-         * Holds an implementation of [Apps] interface. If it was not specified, the default implementation is used.
-         */
-        lateinit var apps: Apps
-
-        /**
-         * Holds an implementation of [Activities] interface. If it was not specified, the default implementation is used.
-         */
-        lateinit var activities: Activities
-
-        /**
-         * Holds an implementation of [Files] interface. If it was not specified, the default implementation is used.
-         */
-        lateinit var files: Files
-
-        /**
-         * Holds an implementation of [Network] interface. If it was not specified, the default implementation is used.
-         */
-        lateinit var network: Network
-
-        /**
-         * Holds an implementation of [Phone] interface. If it was not specified, the default implementation is used.
-         */
-        lateinit var phone: Phone
-
-        /**
-         * Holds an implementation of [Location] interface. If it was not specified, the default implementation is used.
-         */
-        lateinit var location: Location
-
-        /**
-         * Holds an implementation of [Keyboard] interface. If it was not specified, the default implementation is used.
-         */
-        lateinit var keyboard: Keyboard
 
         /**
          * Holds an implementation of [Screenshots] interface. If it was not specified, the default implementation is used.
@@ -530,6 +436,12 @@ data class Kaspresso(
          */
         var failureHandler: FailureHandler? = null
 
+        /**
+         * Sets Kautomator based on sharedTest support (whether tests can ALSO run on the JVM or ONLY on as instrumentation test on devices/emulators)
+         * This is necessary since Robolectric is compatible with Espresso but not with UiAutomator
+         */
+        lateinit var kautomatorConfig: KautomatorConfig
+
         private val defaultsTestRunWatcherInterceptor = DefaultTestRunWatcherInterceptor()
 
         /**
@@ -554,61 +466,128 @@ data class Kaspresso(
             defaultsTestRunWatcherInterceptor.afterEachTest(override, action)
         }
 
+        /**
+         * Holds an implementation of [UiTestLogger] interface for external developer's usage in tests.
+         * If it was not specified, the default implementation with default tag is used.
+         */
+        lateinit var testLogger: UiTestLogger
+
+        /**
+         * UiDevice can only be accessed from Instrumentation tests and never from shared test running with Robolectric
+         */
+        var uiDevice: UiDevice? = null
+
+        private val configurator = Configurator.getInstance()
+
+        /**
+         * Holds an implementation of [AdbServer] interface. If it was not specified, the default implementation is used.
+         */
+        lateinit var adbServer: AdbServer
+
+        /**
+         * Holds an implementation of [Apps] interface. If it was not specified, the default implementation is used.
+         */
+        lateinit var apps: Apps
+
+        /**
+         * Holds an implementation of [Activities] interface. If it was not specified, the default implementation is used.
+         */
+        lateinit var activities: Activities
+
+        /**
+         * Holds an implementation of [Files] interface. If it was not specified, the default implementation is used.
+         */
+        lateinit var files: Files
+
+        /**
+         * Holds an implementation of [Network] interface. If it was not specified, the default implementation is used.
+         */
+        lateinit var network: Network
+
+        /**
+         * Holds an implementation of [Phone] interface. If it was not specified, the default implementation is used.
+         */
+        lateinit var phone: Phone
+
+        /**
+         * Holds an implementation of [Location] interface. If it was not specified, the default implementation is used.
+         */
+        lateinit var location: Location
+
+        /**
+         * Holds an implementation of [Keyboard] interface. If it was not specified, the default implementation is used.
+         */
+        lateinit var keyboard: Keyboard
+
+
         @Suppress("detekt.ComplexMethod")
         private fun postInitVariables() {
-            if (!::kautomatorWaitForIdleSettings.isInitialized) kautomatorWaitForIdleSettings = KautomatorWaitForIdleSettings.default()
 
             if (!::libLogger.isInitialized) libLogger = UiTestLoggerImpl(DEFAULT_LIB_LOGGER_TAG)
             if (!::testLogger.isInitialized) testLogger = UiTestLoggerImpl(DEFAULT_TEST_LOGGER_TAG)
-
-            if (!::adbServer.isInitialized) adbServer = AdbServerImpl(LogLevel.WARN, libLogger)
-            if (!::apps.isInitialized) apps = AppsImpl(libLogger, instrumentation.context, uiDevice, adbServer)
-            if (!::activities.isInitialized) activities = ActivitiesImpl(libLogger)
-            if (!::files.isInitialized) files = FilesImpl(adbServer)
-            if (!::network.isInitialized) network = NetworkImpl(instrumentation.targetContext, adbServer, libLogger)
-            if (!::phone.isInitialized) phone = PhoneImpl(adbServer)
-            if (!::location.isInitialized) location = LocationImpl(adbServer)
-            if (!::keyboard.isInitialized) keyboard = KeyboardImpl(adbServer)
-            if (!::screenshots.isInitialized) {
-                screenshots = ScreenshotsImpl(
-                    libLogger,
-                    CombinedScreenshotMaker(InternalScreenshotMaker(activities), ExternalScreenshotMaker()),
-                    DefaultScreenshotDirectoryProvider(groupByRunNumbers = true),
-                    DefaultScreenshotNameProvider(addTimestamps = false)
-                )
-            }
-            if (!::accessibility.isInitialized) accessibility = AccessibilityImpl()
-            if (!::permissions.isInitialized) permissions = PermissionsImpl(libLogger, uiDevice)
-            if (!::hackPermissions.isInitialized) hackPermissions = HackPermissionsImpl(instrumentation.uiAutomation, libLogger)
-            if (!::exploit.isInitialized) exploit = ExploitImpl(activities, uiDevice, adbServer)
-            if (!::language.isInitialized) language = LanguageImpl(libLogger, instrumentation.targetContext)
-            if (!::logcat.isInitialized) logcat = LogcatImpl(adbServer)
 
             if (!::flakySafetyParams.isInitialized) flakySafetyParams = FlakySafetyParams.default()
             if (!::continuouslyParams.isInitialized) continuouslyParams = ContinuouslyParams.default()
             if (!::autoScrollParams.isInitialized) autoScrollParams = AutoScrollParams.default()
             if (!::stepParams.isInitialized) stepParams = StepParams()
+
+            //kautomator
+            if (!::kautomatorWaitForIdleSettings.isInitialized) kautomatorWaitForIdleSettings = KautomatorWaitForIdleSettings.default()
+            if (!::adbServer.isInitialized) adbServer = kautomatorConfig.getAdbServer(libLogger)//AdbServerImpl(LogLevel.WARN, libLogger)
+            if (!::apps.isInitialized) apps = kautomatorConfig.getApps(libLogger, adbServer)//AppsImpl(libLogger, instrumentation.context, uiDevice, adbServer)
+            if (!::activities.isInitialized) activities = kautomatorConfig.getActivities(libLogger)//ActivitiesImpl(libLogger)
+            if (!::files.isInitialized) files = kautomatorConfig.getFiles(adbServer)
+            if (!::network.isInitialized) network = kautomatorConfig.getNetwork(libLogger, adbServer)
+            if (!::phone.isInitialized) phone = kautomatorConfig.getPhone(adbServer)
+            if (!::location.isInitialized) location = kautomatorConfig.getLocation(adbServer)
+            if (!::keyboard.isInitialized) keyboard = kautomatorConfig.getKeyboard(adbServer)
+            if (!::screenshots.isInitialized) {
+                screenshots = kautomatorConfig.getScreenshots(libLogger, activities)
+                if (!::accessibility.isInitialized) accessibility = kautomatorConfig.getAccessibility()
+                if (!::permissions.isInitialized) permissions = kautomatorConfig.getPermissions(libLogger)
+                if (!::hackPermissions.isInitialized) hackPermissions = kautomatorConfig.getHackPermissions(libLogger)//HackPermissionsImpl(instrumentation.uiAutomation, libLogger)
+                if (!::exploit.isInitialized) exploit = kautomatorConfig.getExploit(adbServer, activities)//ExploitImpl(activities, uiDevice, adbServer)
+                if (!::language.isInitialized) language = kautomatorConfig.getLanguage(libLogger)//LanguageImpl(libLogger, instrumentation.targetContext)
+                if (!::logcat.isInitialized) logcat = kautomatorConfig.getLogcat(adbServer)//LogcatImpl(adbServer)
+            }
         }
 
         @Suppress("detekt.ComplexMethod")
         private fun postBaseInitInterceptors() {
+            if (!::objectWatcherInterceptors.isInitialized) objectWatcherInterceptors = mutableListOf()
+            if (!::deviceWatcherInterceptors.isInitialized) deviceWatcherInterceptors = mutableListOf()
+            if (!::objectBehaviorInterceptors.isInitialized) objectBehaviorInterceptors = mutableListOf()
+            if (!::deviceBehaviorInterceptors.isInitialized) deviceBehaviorInterceptors = mutableListOf()
+
             if (!::viewActionWatcherInterceptors.isInitialized) viewActionWatcherInterceptors = mutableListOf()
             if (!::viewAssertionWatcherInterceptors.isInitialized) viewAssertionWatcherInterceptors = mutableListOf()
             if (!::atomWatcherInterceptors.isInitialized) atomWatcherInterceptors = mutableListOf()
             if (!::webAssertionWatcherInterceptors.isInitialized) webAssertionWatcherInterceptors = mutableListOf()
-            if (!::objectWatcherInterceptors.isInitialized) objectWatcherInterceptors = mutableListOf()
-            if (!::deviceWatcherInterceptors.isInitialized) deviceWatcherInterceptors = mutableListOf()
             if (!::viewBehaviorInterceptors.isInitialized) viewBehaviorInterceptors = mutableListOf()
             if (!::dataBehaviorInterceptors.isInitialized) dataBehaviorInterceptors = mutableListOf()
             if (!::webBehaviorInterceptors.isInitialized) webBehaviorInterceptors = mutableListOf()
-            if (!::objectBehaviorInterceptors.isInitialized) objectBehaviorInterceptors = mutableListOf()
-            if (!::deviceBehaviorInterceptors.isInitialized) deviceBehaviorInterceptors = mutableListOf()
             if (!::stepWatcherInterceptors.isInitialized) stepWatcherInterceptors = mutableListOf()
             if (!::testRunWatcherInterceptors.isInitialized) testRunWatcherInterceptors = mutableListOf()
         }
 
         @Suppress("detekt.ComplexMethod")
         private fun postDefaultInitInterceptors() {
+            //val kautomatorConfig = KautomatorConfigResolver.build(sharedTest)
+
+            if (!::objectWatcherInterceptors.isInitialized) objectWatcherInterceptors = mutableListOf(
+                LoggingObjectWatcherInterceptor(libLogger)
+            )
+
+            if (!::deviceWatcherInterceptors.isInitialized) deviceWatcherInterceptors = mutableListOf(
+                LoggingDeviceWatcherInterceptor(libLogger)
+            )
+
+            if (!::objectBehaviorInterceptors.isInitialized) objectBehaviorInterceptors =
+                kautomatorConfig.getObjectBehaviourInterceptors(libLogger, adbServer, autoScrollParams, flakySafetyParams)
+
+            if (!::deviceBehaviorInterceptors.isInitialized) deviceBehaviorInterceptors =
+                kautomatorConfig.getDeviceBehaviourInterceptors(libLogger, adbServer, flakySafetyParams)
+
             if (!::viewActionWatcherInterceptors.isInitialized) viewActionWatcherInterceptors = mutableListOf(
                 LoggingViewActionWatcherInterceptor(libLogger)
             )
@@ -625,42 +604,14 @@ data class Kaspresso(
                 LoggingWebAssertionWatcherInterceptor(libLogger)
             )
 
-            if (!::objectWatcherInterceptors.isInitialized) objectWatcherInterceptors = mutableListOf(
-                LoggingObjectWatcherInterceptor(libLogger)
-            )
+            if (!::viewBehaviorInterceptors.isInitialized) viewBehaviorInterceptors =
+                kautomatorConfig.getViewBehaviourInterceptors(libLogger, adbServer, autoScrollParams, flakySafetyParams)
 
-            if (!::deviceWatcherInterceptors.isInitialized) deviceWatcherInterceptors = mutableListOf(
-                LoggingDeviceWatcherInterceptor(libLogger)
-            )
+            if (!::dataBehaviorInterceptors.isInitialized) dataBehaviorInterceptors =
+                kautomatorConfig.getDataBehaviourInterceptors(libLogger, adbServer, autoScrollParams, flakySafetyParams)
 
-            if (!::viewBehaviorInterceptors.isInitialized) viewBehaviorInterceptors = mutableListOf(
-                AutoScrollViewBehaviorInterceptor(autoScrollParams, libLogger),
-                SystemDialogSafetyViewBehaviorInterceptor(libLogger, uiDevice, adbServer),
-                FlakySafeViewBehaviorInterceptor(flakySafetyParams, libLogger)
-            )
-
-            if (!::dataBehaviorInterceptors.isInitialized) dataBehaviorInterceptors = mutableListOf(
-                SystemDialogSafetyDataBehaviorInterceptor(libLogger, uiDevice, adbServer),
-                FlakySafeDataBehaviorInterceptor(flakySafetyParams, libLogger)
-            )
-
-            if (!::webBehaviorInterceptors.isInitialized) webBehaviorInterceptors = mutableListOf(
-                AutoScrollWebBehaviorInterceptor(autoScrollParams, libLogger),
-                SystemDialogSafetyWebBehaviorInterceptor(libLogger, uiDevice, adbServer),
-                FlakySafeWebBehaviorInterceptor(flakySafetyParams, libLogger)
-            )
-
-            if (!::objectBehaviorInterceptors.isInitialized) objectBehaviorInterceptors = mutableListOf(
-                AutoScrollObjectBehaviorInterceptor(libLogger, autoScrollParams),
-                UiObjectLoaderBehaviorInterceptor(libLogger),
-                SystemDialogSafetyObjectBehaviorInterceptor(libLogger, uiDevice, adbServer),
-                FlakySafeObjectBehaviorInterceptor(flakySafetyParams, libLogger)
-            )
-
-            if (!::deviceBehaviorInterceptors.isInitialized) deviceBehaviorInterceptors = mutableListOf(
-                SystemDialogSafetyDeviceBehaviorInterceptor(libLogger, uiDevice, adbServer),
-                FlakySafeDeviceBehaviorInterceptor(flakySafetyParams, libLogger)
-            )
+            if (!::webBehaviorInterceptors.isInitialized) webBehaviorInterceptors =
+                kautomatorConfig.getWebBehaviourInterceptors(libLogger, adbServer, autoScrollParams, flakySafetyParams)
 
             if (!::stepWatcherInterceptors.isInitialized) stepWatcherInterceptors = mutableListOf(
                 LoggingStepWatcherInterceptor(libLogger)
@@ -688,25 +639,6 @@ data class Kaspresso(
                 libLogger = libLogger,
                 testLogger = testLogger,
 
-                adbServer = adbServer,
-
-                device = Device(
-                    apps = apps,
-                    activities = activities,
-                    files = files,
-                    network = network,
-                    phone = phone,
-                    location = location,
-                    keyboard = keyboard,
-                    screenshots = screenshots,
-                    accessibility = accessibility,
-                    permissions = permissions,
-                    hackPermissions = hackPermissions,
-                    exploit = exploit,
-                    language = language,
-                    logcat = logcat
-                ),
-
                 params = Params(
                     flakySafetyParams = flakySafetyParams,
                     continuouslyParams = continuouslyParams,
@@ -719,18 +651,21 @@ data class Kaspresso(
                 atomWatcherInterceptors = atomWatcherInterceptors,
                 webAssertionWatcherInterceptors = webAssertionWatcherInterceptors,
 
-                objectWatcherInterceptors = objectWatcherInterceptors,
-                deviceWatcherInterceptors = deviceWatcherInterceptors,
-
                 viewBehaviorInterceptors = viewBehaviorInterceptors,
                 dataBehaviorInterceptors = dataBehaviorInterceptors,
                 webBehaviorInterceptors = webBehaviorInterceptors,
 
-                objectBehaviorInterceptors = objectBehaviorInterceptors,
-                deviceBehaviorInterceptors = deviceBehaviorInterceptors,
-
                 stepWatcherInterceptors = stepWatcherInterceptors,
-                testRunWatcherInterceptors = testRunWatcherInterceptors
+                testRunWatcherInterceptors = testRunWatcherInterceptors,
+
+                adbServer = kautomatorConfig.getAdbServer(libLogger),
+                device = kautomatorConfig.getDevice(libLogger, adbServer, activities),
+
+                objectWatcherInterceptors = emptyList(),
+                deviceWatcherInterceptors = emptyList(),
+
+                objectBehaviorInterceptors = emptyList(),
+                deviceBehaviorInterceptors = emptyList(),
             )
 
             configurator.waitForIdleTimeout = kautomatorWaitForIdleSettings.waitForIdleTimeout

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/kaspresso/KautomatorConfig.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/kaspresso/KautomatorConfig.kt
@@ -1,0 +1,98 @@
+package com.kaspersky.kaspresso.kaspresso
+
+import com.kaspersky.kaspresso.device.Device
+import com.kaspersky.kaspresso.device.accessibility.Accessibility
+import com.kaspersky.kaspresso.device.activities.Activities
+import com.kaspersky.kaspresso.device.apps.Apps
+import com.kaspersky.kaspresso.device.exploit.Exploit
+import com.kaspersky.kaspresso.device.files.Files
+import com.kaspersky.kaspresso.device.keyboard.Keyboard
+import com.kaspersky.kaspresso.device.languages.Language
+import com.kaspersky.kaspresso.device.location.Location
+import com.kaspersky.kaspresso.device.logcat.Logcat
+import com.kaspersky.kaspresso.device.network.Network
+import com.kaspersky.kaspresso.device.permissions.HackPermissions
+import com.kaspersky.kaspresso.device.permissions.Permissions
+import com.kaspersky.kaspresso.device.phone.Phone
+import com.kaspersky.kaspresso.device.screenshots.Screenshots
+import com.kaspersky.kaspresso.device.server.AdbServer
+import com.kaspersky.kaspresso.interceptors.behavior.DataBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.ViewBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.WebBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behaviorkautomator.DeviceBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behaviorkautomator.ObjectBehaviorInterceptor
+import com.kaspersky.kaspresso.logger.UiTestLogger
+import com.kaspersky.kaspresso.params.AutoScrollParams
+import com.kaspersky.kaspresso.params.FlakySafetyParams
+
+interface KautomatorConfig {
+
+    val canRunOnJvm: Boolean
+
+    fun getDevice(libLogger: UiTestLogger, adbServer: AdbServer, activities: Activities): Device?
+
+    fun getAdbServer(libLogger: UiTestLogger): AdbServer
+
+    fun getPermissions(libLogger: UiTestLogger): Permissions
+
+    fun getNetwork(libLogger: UiTestLogger, adbServer: AdbServer): Network
+
+    fun getApps(libLogger: UiTestLogger, adbServer: AdbServer): Apps
+
+    fun getFiles(adbServer: AdbServer): Files
+
+    fun getActivities(libLogger: UiTestLogger): Activities
+
+    fun getPhone(adbServer: AdbServer): Phone
+
+    fun getLocation(adbServer: AdbServer): Location
+
+    fun getKeyboard(adbServer: AdbServer): Keyboard
+
+    fun getScreenshots(libLogger: UiTestLogger, activities: Activities): Screenshots
+
+    fun getAccessibility(): Accessibility
+
+    fun getHackPermissions(libLogger: UiTestLogger): HackPermissions
+
+    fun getExploit(adbServer: AdbServer, activities: Activities): Exploit
+
+    fun getLanguage(libLogger: UiTestLogger): Language
+
+    fun getLogcat(adbServer: AdbServer): Logcat
+
+    fun getObjectBehaviourInterceptors(
+        libLogger: UiTestLogger,
+        adbServer: AdbServer,
+        autoScrollParams: AutoScrollParams,
+        flakySafetyParams: FlakySafetyParams
+    ): MutableList<ObjectBehaviorInterceptor>
+
+    fun getDeviceBehaviourInterceptors(
+        libLogger: UiTestLogger,
+        adbServer: AdbServer,
+        flakySafetyParams: FlakySafetyParams
+    ): MutableList<DeviceBehaviorInterceptor>
+
+    fun getViewBehaviourInterceptors(
+        libLogger: UiTestLogger,
+        adbServer: AdbServer,
+        autoScrollParams: AutoScrollParams,
+        flakySafetyParams: FlakySafetyParams
+    ): MutableList<ViewBehaviorInterceptor>
+
+    fun getDataBehaviourInterceptors(
+        libLogger: UiTestLogger,
+        adbServer: AdbServer,
+        autoScrollParams: AutoScrollParams,
+        flakySafetyParams: FlakySafetyParams
+    ): MutableList<DataBehaviorInterceptor>
+
+    fun getWebBehaviourInterceptors(
+        libLogger: UiTestLogger,
+        adbServer: AdbServer,
+        autoScrollParams: AutoScrollParams,
+        flakySafetyParams: FlakySafetyParams
+    ): MutableList<WebBehaviorInterceptor>
+
+}

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/kaspresso/KautomatorConfigResolver.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/kaspresso/KautomatorConfigResolver.kt
@@ -1,0 +1,10 @@
+package com.kaspersky.kaspresso.kaspresso
+
+object KautomatorConfigResolver {
+
+    fun build(sharedTest: Boolean): KautomatorConfig =
+        when (sharedTest) {
+            true -> KautomatorJvmConfig()
+            false -> KautomatorInstrumentationConfig()
+        }
+}

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/kaspresso/KautomatorInstrumentationConfig.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/kaspresso/KautomatorInstrumentationConfig.kt
@@ -1,0 +1,188 @@
+package com.kaspersky.kaspresso.kaspresso
+
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
+import androidx.test.uiautomator.UiDevice
+import com.kaspersky.adbserver.common.log.logger.LogLevel
+import com.kaspersky.kaspresso.device.Device
+import com.kaspersky.kaspresso.device.accessibility.Accessibility
+import com.kaspersky.kaspresso.device.accessibility.AccessibilityImpl
+import com.kaspersky.kaspresso.device.activities.Activities
+import com.kaspersky.kaspresso.device.activities.ActivitiesImpl
+import com.kaspersky.kaspresso.device.apps.Apps
+import com.kaspersky.kaspresso.device.apps.AppsImpl
+import com.kaspersky.kaspresso.device.exploit.Exploit
+import com.kaspersky.kaspresso.device.exploit.ExploitImpl
+import com.kaspersky.kaspresso.device.files.Files
+import com.kaspersky.kaspresso.device.files.FilesImpl
+import com.kaspersky.kaspresso.device.keyboard.Keyboard
+import com.kaspersky.kaspresso.device.keyboard.KeyboardImpl
+import com.kaspersky.kaspresso.device.languages.Language
+import com.kaspersky.kaspresso.device.languages.LanguageImpl
+import com.kaspersky.kaspresso.device.location.Location
+import com.kaspersky.kaspresso.device.location.LocationImpl
+import com.kaspersky.kaspresso.device.logcat.Logcat
+import com.kaspersky.kaspresso.device.logcat.LogcatImpl
+import com.kaspersky.kaspresso.device.network.Network
+import com.kaspersky.kaspresso.device.network.NetworkImpl
+import com.kaspersky.kaspresso.device.permissions.HackPermissions
+import com.kaspersky.kaspresso.device.permissions.HackPermissionsImpl
+import com.kaspersky.kaspresso.device.permissions.Permissions
+import com.kaspersky.kaspresso.device.permissions.PermissionsImpl
+import com.kaspersky.kaspresso.device.phone.Phone
+import com.kaspersky.kaspresso.device.phone.PhoneImpl
+import com.kaspersky.kaspresso.device.screenshots.Screenshots
+import com.kaspersky.kaspresso.device.screenshots.ScreenshotsImpl
+import com.kaspersky.kaspresso.device.screenshots.screenshotfiles.DefaultScreenshotDirectoryProvider
+import com.kaspersky.kaspresso.device.screenshots.screenshotfiles.DefaultScreenshotNameProvider
+import com.kaspersky.kaspresso.device.screenshots.screenshotmaker.CombinedScreenshotMaker
+import com.kaspersky.kaspresso.device.screenshots.screenshotmaker.ExternalScreenshotMaker
+import com.kaspersky.kaspresso.device.screenshots.screenshotmaker.InternalScreenshotMaker
+import com.kaspersky.kaspresso.device.server.AdbServer
+import com.kaspersky.kaspresso.device.server.AdbServerImpl
+import com.kaspersky.kaspresso.interceptors.behavior.DataBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.ViewBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.WebBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.impl.autoscroll.AutoScrollViewBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.impl.autoscroll.AutoScrollWebBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.impl.flakysafety.FlakySafeDataBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.impl.flakysafety.FlakySafeViewBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.impl.flakysafety.FlakySafeWebBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.impl.systemsafety.SystemDialogSafetyDataBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.impl.systemsafety.SystemDialogSafetyViewBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.impl.systemsafety.SystemDialogSafetyWebBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behaviorkautomator.DeviceBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behaviorkautomator.ObjectBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behaviorkautomator.impl.autoscroll.AutoScrollObjectBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behaviorkautomator.impl.flakysafety.FlakySafeDeviceBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behaviorkautomator.impl.flakysafety.FlakySafeObjectBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behaviorkautomator.impl.loader.UiObjectLoaderBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behaviorkautomator.impl.systemsafety.SystemDialogSafetyDeviceBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behaviorkautomator.impl.systemsafety.SystemDialogSafetyObjectBehaviorInterceptor
+import com.kaspersky.kaspresso.logger.UiTestLogger
+import com.kaspersky.kaspresso.params.AutoScrollParams
+import com.kaspersky.kaspresso.params.FlakySafetyParams
+
+class KautomatorInstrumentationConfig : KautomatorConfig {
+
+    override val canRunOnJvm: Boolean
+        get() = false
+
+    override fun getDevice(libLogger: UiTestLogger, adbServer: AdbServer, activities: Activities): Device =
+        Device(
+            apps = getApps(libLogger, adbServer),
+            files = getFiles(adbServer),
+            network = getNetwork(libLogger, adbServer),
+            activities = getActivities(libLogger),
+            phone = getPhone(adbServer),
+            location = getLocation(adbServer),
+            keyboard = getKeyboard(adbServer),
+            accessibility = getAccessibility(),
+            screenshots = getScreenshots(libLogger, activities),
+            permissions = getPermissions(libLogger),
+            hackPermissions = getHackPermissions(libLogger),
+            exploit = getExploit(adbServer, activities),
+            language = getLanguage(libLogger),
+            logcat = getLogcat(adbServer)
+        )
+
+    override fun getAdbServer(libLogger: UiTestLogger): AdbServer =
+        AdbServerImpl(LogLevel.WARN, libLogger)
+
+    override fun getPermissions(libLogger: UiTestLogger): Permissions =
+        PermissionsImpl(libLogger, uiDevice)
+
+    override fun getNetwork(libLogger: UiTestLogger, adbServer: AdbServer): Network =
+        NetworkImpl(getInstrumentation().targetContext, adbServer, libLogger)
+
+    override fun getApps(libLogger: UiTestLogger, adbServer: AdbServer): Apps =
+        AppsImpl(libLogger, getInstrumentation().context, uiDevice, adbServer)
+
+    override fun getFiles(adbServer: AdbServer): Files = FilesImpl(adbServer)
+
+    override fun getActivities(libLogger: UiTestLogger): Activities = ActivitiesImpl(libLogger)
+
+    override fun getPhone(adbServer: AdbServer): Phone = PhoneImpl(adbServer)
+
+    override fun getLocation(adbServer: AdbServer): Location = LocationImpl(adbServer)
+
+    override fun getKeyboard(adbServer: AdbServer): Keyboard = KeyboardImpl(adbServer)
+
+    override fun getScreenshots(libLogger: UiTestLogger, activities: Activities): Screenshots =
+        ScreenshotsImpl(
+            libLogger,
+            CombinedScreenshotMaker(InternalScreenshotMaker(activities), ExternalScreenshotMaker()),
+            DefaultScreenshotDirectoryProvider(groupByRunNumbers = true),
+            DefaultScreenshotNameProvider(addTimestamps = false)
+        )
+
+    override fun getAccessibility(): Accessibility = AccessibilityImpl()
+
+    override fun getHackPermissions(libLogger: UiTestLogger): HackPermissions =
+        HackPermissionsImpl(getInstrumentation().uiAutomation, libLogger)
+
+    override fun getExploit(adbServer: AdbServer, activities: Activities): Exploit =
+        ExploitImpl(activities, uiDevice, adbServer)
+
+    override fun getLanguage(libLogger: UiTestLogger): Language =
+        LanguageImpl(libLogger, getInstrumentation().targetContext)
+
+    override fun getLogcat(adbServer: AdbServer): Logcat = LogcatImpl(adbServer)
+
+    override fun getObjectBehaviourInterceptors(
+        libLogger: UiTestLogger,
+        adbServer: AdbServer,
+        autoScrollParams: AutoScrollParams,
+        flakySafetyParams: FlakySafetyParams
+    ): MutableList<ObjectBehaviorInterceptor> =
+        mutableListOf(
+            AutoScrollObjectBehaviorInterceptor(libLogger, autoScrollParams),
+            UiObjectLoaderBehaviorInterceptor(libLogger),
+            SystemDialogSafetyObjectBehaviorInterceptor(libLogger, uiDevice, adbServer),
+            FlakySafeObjectBehaviorInterceptor(flakySafetyParams, libLogger)
+        )
+
+    override fun getDeviceBehaviourInterceptors(libLogger: UiTestLogger, adbServer: AdbServer, flakySafetyParams: FlakySafetyParams): MutableList<DeviceBehaviorInterceptor> =
+        mutableListOf(
+            SystemDialogSafetyDeviceBehaviorInterceptor(libLogger, uiDevice, adbServer),
+            FlakySafeDeviceBehaviorInterceptor(flakySafetyParams, libLogger)
+        )
+
+
+    override fun getViewBehaviourInterceptors(
+        libLogger: UiTestLogger,
+        adbServer: AdbServer,
+        autoScrollParams: AutoScrollParams,
+        flakySafetyParams: FlakySafetyParams
+    ): MutableList<ViewBehaviorInterceptor> =
+        mutableListOf(
+            AutoScrollViewBehaviorInterceptor(autoScrollParams, libLogger),
+            SystemDialogSafetyViewBehaviorInterceptor(libLogger, uiDevice, adbServer),
+            FlakySafeViewBehaviorInterceptor(flakySafetyParams, libLogger)
+        )
+
+    override fun getDataBehaviourInterceptors(
+        libLogger: UiTestLogger,
+        adbServer: AdbServer,
+        autoScrollParams: AutoScrollParams,
+        flakySafetyParams: FlakySafetyParams
+    ): MutableList<DataBehaviorInterceptor> = mutableListOf(
+        SystemDialogSafetyDataBehaviorInterceptor(libLogger, uiDevice, adbServer),
+        FlakySafeDataBehaviorInterceptor(flakySafetyParams, libLogger)
+    )
+
+
+    override fun getWebBehaviourInterceptors(
+        libLogger: UiTestLogger,
+        adbServer: AdbServer,
+        autoScrollParams: AutoScrollParams,
+        flakySafetyParams: FlakySafetyParams
+    ): MutableList<WebBehaviorInterceptor> =
+        mutableListOf(
+            AutoScrollWebBehaviorInterceptor(autoScrollParams, libLogger),
+            SystemDialogSafetyWebBehaviorInterceptor(libLogger, uiDevice, adbServer),
+            FlakySafeWebBehaviorInterceptor(flakySafetyParams, libLogger)
+        )
+
+    private val uiDevice: UiDevice = UiDevice.getInstance(getInstrumentation())
+}
+

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/kaspresso/KautomatorJvmConfig.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/kaspresso/KautomatorJvmConfig.kt
@@ -1,0 +1,337 @@
+package com.kaspersky.kaspresso.kaspresso
+
+import android.app.Activity
+import android.net.Uri
+import com.kaspersky.kaspresso.device.Device
+import com.kaspersky.kaspresso.device.accessibility.Accessibility
+import com.kaspersky.kaspresso.device.activities.Activities
+import com.kaspersky.kaspresso.device.apps.Apps
+import com.kaspersky.kaspresso.device.exploit.Exploit
+import com.kaspersky.kaspresso.device.files.Files
+import com.kaspersky.kaspresso.device.keyboard.Keyboard
+import com.kaspersky.kaspresso.device.languages.Language
+import com.kaspersky.kaspresso.device.location.Location
+import com.kaspersky.kaspresso.device.logcat.Logcat
+import com.kaspersky.kaspresso.device.logcat.LogcatBufferSize
+import com.kaspersky.kaspresso.device.network.Network
+import com.kaspersky.kaspresso.device.permissions.HackPermissions
+import com.kaspersky.kaspresso.device.permissions.Permissions
+import com.kaspersky.kaspresso.device.phone.Phone
+import com.kaspersky.kaspresso.device.screenshots.Screenshots
+import com.kaspersky.kaspresso.device.server.AdbServer
+import com.kaspersky.kaspresso.interceptors.behavior.DataBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.ViewBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.WebBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.impl.autoscroll.AutoScrollViewBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.impl.autoscroll.AutoScrollWebBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.impl.flakysafety.FlakySafeDataBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.impl.flakysafety.FlakySafeViewBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behavior.impl.flakysafety.FlakySafeWebBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behaviorkautomator.DeviceBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behaviorkautomator.ObjectBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behaviorkautomator.impl.autoscroll.AutoScrollObjectBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behaviorkautomator.impl.flakysafety.FlakySafeDeviceBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behaviorkautomator.impl.flakysafety.FlakySafeObjectBehaviorInterceptor
+import com.kaspersky.kaspresso.interceptors.behaviorkautomator.impl.loader.UiObjectLoaderBehaviorInterceptor
+import com.kaspersky.kaspresso.logger.UiTestLogger
+import com.kaspersky.kaspresso.params.AutoScrollParams
+import com.kaspersky.kaspresso.params.FlakySafetyParams
+import java.util.*
+
+/**
+ * Contains empty or default implementations of all those interfaces that require UiAutomator in order
+ * to make it JVM compatible
+ */
+class KautomatorJvmConfig : KautomatorConfig {
+
+    override val canRunOnJvm: Boolean
+        get() = true
+
+    override fun getDevice(libLogger: UiTestLogger, adbServer: AdbServer, activities: Activities): Device? = null
+
+    override fun getAdbServer(libLogger: UiTestLogger): AdbServer = object : AdbServer {
+        override fun performCmd(vararg commands: String): List<String> = emptyList()
+
+        override fun performAdb(vararg commands: String): List<String> = emptyList()
+
+        override fun performShell(vararg commands: String): List<String> = emptyList()
+
+        override fun disconnectServer() {
+            //no-op
+        }
+    }
+
+    override fun getPermissions(libLogger: UiTestLogger): Permissions = object : Permissions {
+        override fun allowViaDialog() {
+            //no-op
+        }
+
+        override fun denyViaDialog() {
+            //no-op
+        }
+
+        override fun isDialogVisible(): Boolean = false
+
+        override fun clickOn(button: Permissions.Button) {
+            //no-op
+        }
+    }
+
+    override fun getNetwork(libLogger: UiTestLogger, adbServer: AdbServer): Network = object : Network {
+        override fun enable() {
+            //no-op
+        }
+
+        override fun disable() {
+            //no-op
+        }
+
+        override fun toggleMobileData(enable: Boolean) {
+            //no-op
+        }
+
+        override fun toggleWiFi(enable: Boolean) {
+            //no-op
+        }
+    }
+
+    override fun getApps(libLogger: UiTestLogger, adbServer: AdbServer): Apps =
+        object : Apps {
+            override val targetAppLauncherPackageName: String
+                get() = "JVM launcher package name"
+            override val targetAppPackageName: String
+                get() = "JVM package name"
+
+            override fun install(apkPath: String) {
+                //no-op
+            }
+
+            override fun installIfNotExists(packageName: String, apkPath: String) {
+                //no-op
+            }
+
+            override fun uninstall(packageName: String) {
+                //no-op
+            }
+
+            override fun uninstallIfExists(packageName: String) {
+                //no-op
+            }
+
+            override fun isInstalled(packageName: String): Boolean = false
+
+            override fun waitForLauncher(timeout: Long, launcherPackageName: String) {
+                //no-op
+            }
+
+            override fun waitForAppLaunchAndReady(timeout: Long, packageName: String) {
+                //no-op
+            }
+
+            override fun openUrlInChrome(url: String) {
+                //no-op
+            }
+
+            override fun launch(packageName: String, data: Uri?) {
+                //no-op
+            }
+
+            override fun openRecent(contentDescription: String) {
+                //no-op
+            }
+
+            override fun kill(packageName: String) {
+                //no-op
+            }
+        }
+
+    override fun getFiles(adbServer: AdbServer): Files = object : Files {
+        override fun push(serverPath: String, devicePath: String) {
+            //no-op
+        }
+
+        override fun remove(path: String) {
+            //no-op
+        }
+
+        override fun pull(devicePath: String, serverPath: String) {
+            //no-op
+        }
+    }
+
+    override fun getActivities(libLogger: UiTestLogger): Activities = object : Activities {
+        override fun getResumed(): Activity? = null
+
+        override fun isCurrent(clazz: Class<out Activity>) {
+            //no-op
+        }
+    }
+
+    override fun getPhone(adbServer: AdbServer): Phone = object : Phone {
+        override fun emulateCall(number: String) {
+            //no-op
+        }
+
+        override fun cancelCall(number: String) {
+            //no-op
+        }
+
+        override fun receiveSms(number: String, text: String) {
+            //no-op
+        }
+    }
+
+    override fun getLocation(adbServer: AdbServer): Location = object : Location {
+        override fun enableGps() {
+            //no-op
+        }
+
+        override fun disableGps() {
+            //no-op
+        }
+
+        override fun setLocation(lat: Double, lon: Double) {
+            //no-op
+        }
+    }
+
+    override fun getKeyboard(adbServer: AdbServer): Keyboard = object : Keyboard {
+        override fun typeText(text: String) {
+            //no-op
+        }
+
+        override fun sendEvent(keyEvent: Int) {
+            //no-op
+        }
+    }
+
+    override fun getScreenshots(libLogger: UiTestLogger, activities: Activities): Screenshots = object : Screenshots {
+        override fun take(tag: String) {
+            //no-op
+        }
+    }
+
+    override fun getAccessibility(): Accessibility = object : Accessibility {
+        override fun enable(packageName: String, className: String) {
+            //no-op
+        }
+
+        override fun disable() {
+            //no-op
+        }
+    }
+
+    override fun getHackPermissions(libLogger: UiTestLogger): HackPermissions = object : HackPermissions {
+        override fun grant(packageName: String, permission: String): Boolean = false
+    }
+
+    override fun getExploit(adbServer: AdbServer, activities: Activities): Exploit = object : Exploit {
+        override fun rotate() {
+            //no-op
+        }
+
+        override fun setOrientation(deviceOrientation: Exploit.DeviceOrientation) {
+            //no-op
+        }
+
+        override fun setAutoRotationEnabled(enabled: Boolean) {
+            //no-op
+        }
+
+        override fun pressBack(failTestIfAppUnderTestClosed: Boolean) {
+            //no-op
+        }
+
+        override fun pressHome(): Boolean = false
+    }
+
+    override fun getLanguage(libLogger: UiTestLogger): Language = object : Language {
+        override fun switchInApp(locale: Locale) {
+            //no-op
+        }
+    }
+
+    override fun getLogcat(adbServer: AdbServer): Logcat = object : Logcat {
+        override fun disableChatty() {
+            //no-op
+        }
+
+        override fun setBufferSize(size: LogcatBufferSize) {
+            //no-op
+        }
+
+        override fun setDefaultBufferSize() {
+            //no-op
+        }
+
+        override fun clear(buffer: Logcat.Buffer) {
+            //no-op
+        }
+
+        override fun readLogcatRows(
+            excludePattern: String?,
+            excludePatternIsIgnoreCase: Boolean,
+            includePattern: String?,
+            includePatternIsIgnoreCase: Boolean,
+            buffer: Logcat.Buffer,
+            rowLimit: Int?
+        ): List<String> = emptyList()
+
+        override fun readLogcatRows(
+            excludePattern: String?,
+            excludePatternIsIgnoreCase: Boolean,
+            includePattern: String?,
+            includePatternIsIgnoreCase: Boolean,
+            buffer: Logcat.Buffer,
+            rowLimit: Int?,
+            readingBlock: (logcatRow: String) -> Boolean
+        ): Boolean = false
+    }
+
+    override fun getObjectBehaviourInterceptors(
+        libLogger: UiTestLogger,
+        adbServer: AdbServer,
+        autoScrollParams: AutoScrollParams,
+        flakySafetyParams: FlakySafetyParams
+    ): MutableList<ObjectBehaviorInterceptor> = mutableListOf(
+        AutoScrollObjectBehaviorInterceptor(libLogger, autoScrollParams),
+        UiObjectLoaderBehaviorInterceptor(libLogger),
+        FlakySafeObjectBehaviorInterceptor(flakySafetyParams, libLogger)
+    )
+
+    override fun getDeviceBehaviourInterceptors(libLogger: UiTestLogger, adbServer: AdbServer, flakySafetyParams: FlakySafetyParams): MutableList<DeviceBehaviorInterceptor> =
+        mutableListOf(
+            FlakySafeDeviceBehaviorInterceptor(flakySafetyParams, libLogger)
+        )
+
+    override fun getViewBehaviourInterceptors(
+        libLogger: UiTestLogger,
+        adbServer: AdbServer,
+        autoScrollParams: AutoScrollParams,
+        flakySafetyParams: FlakySafetyParams
+    ): MutableList<ViewBehaviorInterceptor> =
+        mutableListOf(
+            AutoScrollViewBehaviorInterceptor(autoScrollParams, libLogger),
+            FlakySafeViewBehaviorInterceptor(flakySafetyParams, libLogger)
+        )
+
+    override fun getDataBehaviourInterceptors(
+        libLogger: UiTestLogger,
+        adbServer: AdbServer,
+        autoScrollParams: AutoScrollParams,
+        flakySafetyParams: FlakySafetyParams
+    ): MutableList<DataBehaviorInterceptor> = mutableListOf(
+        FlakySafeDataBehaviorInterceptor(flakySafetyParams, libLogger)
+    )
+
+    override fun getWebBehaviourInterceptors(
+        libLogger: UiTestLogger,
+        adbServer: AdbServer,
+        autoScrollParams: AutoScrollParams,
+        flakySafetyParams: FlakySafetyParams
+    ): MutableList<WebBehaviorInterceptor> =
+        mutableListOf(
+            AutoScrollWebBehaviorInterceptor(autoScrollParams, libLogger),
+            FlakySafeWebBehaviorInterceptor(flakySafetyParams, libLogger)
+        )
+}

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/api/testcase/BaseTestCase.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/api/testcase/BaseTestCase.kt
@@ -36,7 +36,7 @@ abstract class BaseTestCase<InitData, Data>(
     private val testAssistantsProvider = TestAssistantsProviderImpl(kaspresso)
 
     override val adbServer: AdbServer = testAssistantsProvider.adbServer
-    override val device: Device = testAssistantsProvider.device
+    override val device: Device? = testAssistantsProvider.device
     override val testLogger: UiTestLogger = testAssistantsProvider.testLogger
     override val params: Params = testAssistantsProvider.params
 

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/api/testcase/DocLocScreenshotTestCase.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/api/testcase/DocLocScreenshotTestCase.kt
@@ -122,7 +122,7 @@ abstract class DocLocScreenshotTestCase(
         screenshotCapturer = DocLocScreenshotCapturer(
             logger = logger,
             screenshotMaker = ExternalScreenshotMaker(),
-            metadataSaver = MetadataSaver(kaspresso.device.activities, kaspresso.device.apps, logger),
+            metadataSaver = MetadataSaver(kaspresso.device?.activities, kaspresso.device?.apps, logger),
             screenshotDirectoryProvider = screenshotDirectoryProvider,
             screenshotNameProvider = screenshotNameProvider,
             screenshotRootDir = screenshotsDir

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/testassistants/TestAssistantsProvider.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/testassistants/TestAssistantsProvider.kt
@@ -11,7 +11,7 @@ import com.kaspersky.kaspresso.params.Params
  */
 interface TestAssistantsProvider {
 
-    val device: Device
+    val device: Device?
     val adbServer: AdbServer
     val testLogger: UiTestLogger
     val params: Params

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/testassistants/TestAssistantsProviderImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/testassistants/TestAssistantsProviderImpl.kt
@@ -8,7 +8,7 @@ import com.kaspersky.kaspresso.params.Params
 
 internal class TestAssistantsProviderImpl(kaspresso: Kaspresso) : TestAssistantsProvider {
 
-    override val device: Device = kaspresso.device
+    override val device: Device? = kaspresso.device
     override val adbServer: AdbServer = kaspresso.adbServer
     override val testLogger: UiTestLogger = kaspresso.testLogger
     override val params: Params = kaspresso.params

--- a/samples/kaspresso-sample/build.gradle.kts
+++ b/samples/kaspresso-sample/build.gradle.kts
@@ -9,8 +9,37 @@ android {
         testInstrumentationRunnerArguments["clearPackageData"] = "true"
     }
 
+    sourceSets {
+        val main by getting {
+            java.srcDir("src/main/kotlin")
+        }
+
+        //configure shared test folder
+        val sharedTestFolder = "src/sharedTest/kotlin"
+        val androidTest by getting {
+            java.srcDirs("src/andoroidTest/kotlin", sharedTestFolder )
+        }
+        val test by getting {
+            java.srcDirs("src/test/java", sharedTestFolder )
+        }
+    }
+
     testOptions {
         execution = "ANDROIDX_TEST_ORCHESTRATOR"
+
+        //run nitrogen
+        unitTests.isReturnDefaultValues = true
+        unitTests.isIncludeAndroidResources = true
+    }
+
+    //This is necessary to use activityScenarioRule in tests
+    compileOptions{
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 }
 
@@ -22,6 +51,21 @@ dependencies {
     androidTestImplementation(libs.runner)
     androidTestImplementation(libs.junit)
     androidTestImplementation(projects.kaspresso)
+    androidTestImplementation(libs.androidXRules)
+    androidTestImplementation(libs.androidXTestKtx)
+    androidTestImplementation(libs.androidXTest)
 
     androidTestUtil(libs.orchestrator)
+
+    testImplementation(libs.runner)
+    testImplementation(libs.junit)
+    testImplementation(projects.kaspresso)
+    testImplementation(libs.androidXRules)
+    testImplementation(libs.androidXTestKtx)
+    testImplementation(libs.androidXTest)
+    testImplementation(libs.kakao)
+    testImplementation(libs.robolectric)
+
+    debugImplementation(libs.fragmentTesting)
+
 }

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceAccessibilitySampleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceAccessibilitySampleTest.kt
@@ -40,21 +40,21 @@ class DeviceAccessibilitySampleTest : TestCase() {
         assumeTrue(Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
 
         before {
-            device.accessibility.disable()
+            device!!.accessibility.disable()
         }.after {
-            device.accessibility.disable()
+            device!!.accessibility.disable()
         }.run {
 
             step("Enable accessibility service") {
-                device.accessibility.enable(
-                    device.targetContext.packageName,
+                device!!.accessibility.enable(
+                    device!!.targetContext.packageName,
                     SERVICE_CLASS_NAME
                 )
                 assertTrueSafely { isAccessibilityServiceEnabled() }
             }
 
             step("Disable accessibility service") {
-                device.accessibility.disable()
+                device!!.accessibility.disable()
                 assertFalseSafely { isAccessibilityServiceEnabled() }
             }
         }
@@ -62,7 +62,7 @@ class DeviceAccessibilitySampleTest : TestCase() {
 
     private fun BaseTestContext.isAccessibilityServiceEnabled(): Boolean {
         return Settings.Secure.getString(
-            device.targetContext.contentResolver,
+            device!!.targetContext.contentResolver,
             ENABLED_ACCESSIBILITY_SERVICES
         )?.contains(SERVICE_CLASS_NAME) ?: false
     }

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceActivitiesSampleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceActivitiesSampleTest.kt
@@ -26,11 +26,11 @@ class DeviceActivitiesSampleTest : TestCase() {
         run {
 
             step("Check if MainActivity is currently resumed") {
-                device.activities.isCurrent(MainActivity::class.java)
+                device!!.activities.isCurrent(MainActivity::class.java)
             }
 
             step("Check if currently resumed activity is an instance of MainActivity") {
-                assertThat(device.activities.getResumed(), instanceOf(MainActivity::class.java))
+                assertThat(device!!.activities.getResumed(), instanceOf(MainActivity::class.java))
             }
         }
     }

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceAppSampleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceAppSampleTest.kt
@@ -40,12 +40,12 @@ class DeviceAppSampleTest : TestCase() {
     fun test() {
         run {
             step("Install hello world apk") {
-                device.apps.install(TEST_APK_FILE_RELATIVE_PATH)
+                device!!.apps.install(TEST_APK_FILE_RELATIVE_PATH)
                 assertTrue(isAppInstalled(adbServer, TEST_APK_PACKAGE_NAME))
             }
 
             step("Delete the application") {
-                device.apps.uninstall(TEST_APK_PACKAGE_NAME)
+                device!!.apps.uninstall(TEST_APK_PACKAGE_NAME)
                 assertFalse(isAppInstalled(adbServer, TEST_APK_PACKAGE_NAME))
             }
         }

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceExploitSampleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceExploitSampleTest.kt
@@ -27,21 +27,21 @@ class DeviceExploitSampleTest : TestCase() {
     @Test
     fun exploitSampleTest() {
         before {
-            device.exploit.setOrientation(Exploit.DeviceOrientation.Portrait)
-            device.exploit.setAutoRotationEnabled(true)
+            device!!.exploit.setOrientation(Exploit.DeviceOrientation.Portrait)
+            device!!.exploit.setAutoRotationEnabled(true)
         }.after {
-            device.exploit.setOrientation(Exploit.DeviceOrientation.Portrait)
-            device.exploit.setAutoRotationEnabled(true)
+            device!!.exploit.setOrientation(Exploit.DeviceOrientation.Portrait)
+            device!!.exploit.setAutoRotationEnabled(true)
         }.run {
 
             step("Change orientation manually") {
-                device.exploit.setOrientation(Exploit.DeviceOrientation.Landscape)
+                device!!.exploit.setOrientation(Exploit.DeviceOrientation.Landscape)
                 assertTrueSafely {
                     Configuration.ORIENTATION_LANDSCAPE ==
                             activityTestRule.activity.resources.configuration.orientation
                 }
 
-                device.exploit.setOrientation(Exploit.DeviceOrientation.Portrait)
+                device!!.exploit.setOrientation(Exploit.DeviceOrientation.Portrait)
                 assertTrueSafely {
                     Configuration.ORIENTATION_PORTRAIT ==
                             activityTestRule.activity.resources.configuration.orientation
@@ -49,7 +49,7 @@ class DeviceExploitSampleTest : TestCase() {
             }
 
             step("Rotate device") {
-                device.exploit.rotate()
+                device!!.exploit.rotate()
                 assertTrueSafely {
                     Configuration.ORIENTATION_LANDSCAPE ==
                             activityTestRule.activity.resources.configuration.orientation
@@ -63,13 +63,13 @@ class DeviceExploitSampleTest : TestCase() {
                     }
                 }
 
-                device.exploit.pressBack(true)
-                device.activities.isCurrent(MainActivity::class.java) // Asserts that MainActivity is resumed
+                device!!.exploit.pressBack(true)
+                device!!.activities.isCurrent(MainActivity::class.java) // Asserts that MainActivity is resumed
             }
 
             step("Press home button") {
-                device.exploit.pressHome()
-                assertNull(device.activities.getResumed())
+                device!!.exploit.pressHome()
+                assertNull(device!!.activities.getResumed())
             }
         }
     }

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceFilesSampleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceFilesSampleTest.kt
@@ -39,14 +39,14 @@ class DeviceFilesSampleTest : TestCase() {
         run {
 
             step("Push $FILE_RELATIVE_PATH to device") {
-                device.files.push(FILE_RELATIVE_PATH, Environment.getExternalStorageDirectory().absolutePath)
+                device!!.files.push(FILE_RELATIVE_PATH, Environment.getExternalStorageDirectory().absolutePath)
                 val file = File(Environment.getExternalStorageDirectory(), FILE_NAME)
                 assertTrue(file.exists())
             }
 
             step("Delete pushed file") {
                 val file = File(Environment.getExternalStorageDirectory(), FILE_NAME)
-                device.files.remove(file.absolutePath)
+                device!!.files.remove(file.absolutePath)
                 assertFalse(file.exists())
             }
         }

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceHackPermissionsSampleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceHackPermissionsSampleTest.kt
@@ -38,7 +38,7 @@ class DeviceHackPermissionsSampleTest : TestCase() {
 
         run {
             step("Request permissions") {
-                device.hackPermissions.grant(device.targetContext.packageName, Manifest.permission.READ_CALL_LOG)
+                device!!.hackPermissions.grant(device!!.targetContext.packageName, Manifest.permission.READ_CALL_LOG)
                 // Contacts permission should be granted now
                 assertTrue(hasCallLogPermission())
             }
@@ -46,6 +46,6 @@ class DeviceHackPermissionsSampleTest : TestCase() {
     }
 
     private fun BaseTestContext.hasCallLogPermission(): Boolean =
-        device.targetContext.checkSelfPermission(Manifest.permission.READ_CALL_LOG) ==
+        device!!.targetContext.checkSelfPermission(Manifest.permission.READ_CALL_LOG) ==
                 PackageManager.PERMISSION_GRANTED
 }

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceKeyboardSampleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceKeyboardSampleTest.kt
@@ -36,7 +36,7 @@ class DeviceKeyboardSampleTest : TestCase() {
             step("Type text using [Keyboard.typeText]") {
                 DeviceSampleScreen {
                     input {
-                        device.keyboard.typeText(TEXT_TO_BE_TYPED)
+                        device!!.keyboard.typeText(TEXT_TO_BE_TYPED)
                         hasText(TEXT_TO_BE_TYPED)
                     }
                 }
@@ -53,15 +53,15 @@ class DeviceKeyboardSampleTest : TestCase() {
                 }
 
                 // Type `kaspresso`
-                device.keyboard.sendEvent(KeyEvent.KEYCODE_K)
-                device.keyboard.sendEvent(KeyEvent.KEYCODE_A)
-                device.keyboard.sendEvent(KeyEvent.KEYCODE_S)
-                device.keyboard.sendEvent(KeyEvent.KEYCODE_P)
-                device.keyboard.sendEvent(KeyEvent.KEYCODE_R)
-                device.keyboard.sendEvent(KeyEvent.KEYCODE_E)
-                device.keyboard.sendEvent(KeyEvent.KEYCODE_S)
-                device.keyboard.sendEvent(KeyEvent.KEYCODE_S)
-                device.keyboard.sendEvent(KeyEvent.KEYCODE_O)
+                device!!.keyboard.sendEvent(KeyEvent.KEYCODE_K)
+                device!!.keyboard.sendEvent(KeyEvent.KEYCODE_A)
+                device!!.keyboard.sendEvent(KeyEvent.KEYCODE_S)
+                device!!.keyboard.sendEvent(KeyEvent.KEYCODE_P)
+                device!!.keyboard.sendEvent(KeyEvent.KEYCODE_R)
+                device!!.keyboard.sendEvent(KeyEvent.KEYCODE_E)
+                device!!.keyboard.sendEvent(KeyEvent.KEYCODE_S)
+                device!!.keyboard.sendEvent(KeyEvent.KEYCODE_S)
+                device!!.keyboard.sendEvent(KeyEvent.KEYCODE_O)
 
                 DeviceSampleScreen {
                     input {

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceLanguageSampleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceLanguageSampleTest.kt
@@ -30,13 +30,13 @@ class DeviceLanguageSampleTest : TestCase() {
     @Test
     fun languageSampleTest() {
         before {
-            default = device.targetContext.resources.configuration.locales[0]
+            default = device!!.targetContext.resources.configuration.locales[0]
         }.after {
-            device.language.switchInApp(default)
+            device!!.language.switchInApp(default)
         }.run {
 
             step("Change locale to english") {
-                device.language.switchInApp(Locale.ENGLISH)
+                device!!.language.switchInApp(Locale.ENGLISH)
                 // it's so important to reload current active Activity
                 // you can do it using activityTestRule or manipulating in the Application through great Kaspresso
                 activityTestRule.finishActivity()
@@ -54,7 +54,7 @@ class DeviceLanguageSampleTest : TestCase() {
             }
 
             step("Change locale to russian") {
-                device.language.switchInApp(Locale("ru"))
+                device!!.language.switchInApp(Locale("ru"))
                 // it's so important to reload current active Activity
                 // you can do it using activityTestRule or manipulating in the Application through great Kaspresso
                 activityTestRule.finishActivity()

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceLocationSampleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceLocationSampleTest.kt
@@ -61,26 +61,26 @@ class DeviceLocationSampleTest : TestCase() {
     @Test
     fun locationSampleTest() {
         before {
-            device.location.enableGps()
-            manager = device.targetContext.getSystemService(LocationManager::class.java)
+            device!!.location.enableGps()
+            manager = device!!.targetContext.getSystemService(LocationManager::class.java)
         }.after {
-            device.location.enableGps()
+            device!!.location.enableGps()
         }.run {
 
             step("Disable GPS") {
-                device.location.disableGps()
+                device!!.location.disableGps()
                 Screen.idle(GPS_SWITCH_DELAY)
                 assertFalse(manager.isProviderEnabled(LocationManager.GPS_PROVIDER))
             }
 
             step("Enable GPS") {
-                device.location.enableGps()
+                device!!.location.enableGps()
                 Screen.idle(GPS_SWITCH_DELAY)
                 assertTrue(manager.isProviderEnabled(LocationManager.GPS_PROVIDER))
             }
 
             step("Set fake location") {
-                device.location.setLocation(
+                device!!.location.setLocation(
                     MUNICH_LOCATION_LAT,
                     MUNICH_LOCATION_LNG
                 )

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceLogcatSampleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceLogcatSampleTest.kt
@@ -17,13 +17,13 @@ class DeviceLogcatSampleTest : TestCase() {
     @Test
     fun logcatTest() {
         before {
-            device.logcat.setBufferSize(LogcatBufferSize(8, LogcatBufferSize.Dimension.MEGABYTES))
-            device.logcat.disableChatty()
-            device.logcat.clear()
+            device!!.logcat.setBufferSize(LogcatBufferSize(8, LogcatBufferSize.Dimension.MEGABYTES))
+            device!!.logcat.disableChatty()
+            device!!.logcat.clear()
         }.after {
         }.run {
             step("Get logcat from device as list of strings") {
-                val logcatList = device.logcat.readLogcatRows()
+                val logcatList = device!!.logcat.readLogcatRows()
                 assertTrue(logcatList.isNotEmpty())
                 assertTrue(logcatList.any { logcatRow ->
                     logcatRow.contains("beginning of main")
@@ -33,14 +33,14 @@ class DeviceLogcatSampleTest : TestCase() {
             step("Filter logcat by excludePattern and case sensitivity") {
                 testLogger.i("Test1Row")
 
-                val logcatListCaseSensitive = device.logcat.readLogcatRows(
+                val logcatListCaseSensitive = device!!.logcat.readLogcatRows(
                     excludePattern = "test1row"
                 )
                 assertTrue(logcatListCaseSensitive.any { logcatRow ->
                     logcatRow.contains("Test1Row")
                 })
 
-                val logcatListCaseInsensitive = device.logcat.readLogcatRows(
+                val logcatListCaseInsensitive = device!!.logcat.readLogcatRows(
                     excludePattern = "test1row",
                     excludePatternIsIgnoreCase = true
                 )
@@ -53,7 +53,7 @@ class DeviceLogcatSampleTest : TestCase() {
                 repeat(10) { testLogger.i("test2row$it") }
 
                 // exclude all rows
-                val logcatListIntervalFilter = device.logcat.readLogcatRows(
+                val logcatListIntervalFilter = device!!.logcat.readLogcatRows(
                     excludePattern = "test2row[0-9]"
                 )
                 assertTrue(logcatListIntervalFilter.none { logcatRow ->
@@ -61,7 +61,7 @@ class DeviceLogcatSampleTest : TestCase() {
                 })
 
                 // exclude only 2 rows
-                val logcatListOrFilter = device.logcat.readLogcatRows(
+                val logcatListOrFilter = device!!.logcat.readLogcatRows(
                     excludePattern = "test2row2|test2row4"
                 )
                 assertTrue(logcatListOrFilter.none { logcatRow ->
@@ -77,7 +77,7 @@ class DeviceLogcatSampleTest : TestCase() {
             step("Filter logcat by includePattern") {
                 testLogger.i("Test3Row")
 
-                val logcatList = device.logcat.readLogcatRows(
+                val logcatList = device!!.logcat.readLogcatRows(
                     includePattern = "test3row",
                     includePatternIsIgnoreCase = true
                 )
@@ -90,7 +90,7 @@ class DeviceLogcatSampleTest : TestCase() {
                 repeat(10) { testLogger.i("Test4Row$it") }
                 testLogger.i("Test4RowOnlyYou")
 
-                val logcatList = device.logcat.readLogcatRows(
+                val logcatList = device!!.logcat.readLogcatRows(
                     includePattern = "test4row",
                     includePatternIsIgnoreCase = true,
                     excludePattern = "test4row[0-9]",
@@ -105,12 +105,12 @@ class DeviceLogcatSampleTest : TestCase() {
             step("Limit rows output") {
                 repeat(100) { testLogger.i("Test5Row$it") }
 
-                val logcatList10Limit = device.logcat.readLogcatRows(
+                val logcatList10Limit = device!!.logcat.readLogcatRows(
                     rowLimit = 10
                 )
                 assertEquals(11, logcatList10Limit.size)
 
-                val logcatList50Limit = device.logcat.readLogcatRows(
+                val logcatList50Limit = device!!.logcat.readLogcatRows(
                     rowLimit = 50
                 )
                 assertEquals(51, logcatList50Limit.size)
@@ -119,22 +119,22 @@ class DeviceLogcatSampleTest : TestCase() {
             step("Using reader block") {
                 repeat(100) { testLogger.i("Test6Row$it") }
 
-                var fullLogcatList = device.logcat.readLogcatRows()
+                var fullLogcatList = device!!.logcat.readLogcatRows()
 
                 var inneContainsSize = 0
-                val isContainsBreaked = device.logcat.readLogcatRows { logcatRow ->
+                val isContainsBreaked = device!!.logcat.readLogcatRows { logcatRow ->
                     inneContainsSize++
                     logcatRow.contains("Test6Row42")
                 }
 
                 var innerNotContainsSize = 0
-                val isNotContainsBreaked = device.logcat.readLogcatRows { logcatRow ->
+                val isNotContainsBreaked = device!!.logcat.readLogcatRows { logcatRow ->
                     innerNotContainsSize++
                     logcatRow.contains("LogcatWillNotContainThisRow :)")
                 }
 
                 var indexOfBeginningRow = 0
-                val isBreakedOnBeginningRow = device.logcat.readLogcatRows { logcatRow ->
+                val isBreakedOnBeginningRow = device!!.logcat.readLogcatRows { logcatRow ->
                     indexOfBeginningRow++
                     logcatRow.contains("beginning of")
                 }

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceNetworkSampleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceNetworkSampleTest.kt
@@ -38,34 +38,34 @@ class DeviceNetworkSampleTest : TestCase() {
     @Test
     fun networkSampleTest() {
         before {
-            device.network.enable()
+            device!!.network.enable()
         }.after {
-            device.network.enable()
+            device!!.network.enable()
         }.run {
 
             step("Disable network") {
-                device.network.disable()
+                device!!.network.disable()
                 assertFalseSafely { isDataConnected() }
                 checkWifi(desiredState = false)
             }
 
             step("Enable network") {
-                device.network.enable()
+                device!!.network.enable()
                 assertTrueSafely { isDataConnected() }
                 checkWifi(desiredState = true)
             }
 
             step("Toggle WiFi") {
-                device.network.toggleWiFi(false)
+                device!!.network.toggleWiFi(false)
                 checkWifi(desiredState = false)
-                device.network.toggleWiFi(true)
+                device!!.network.toggleWiFi(true)
                 checkWifi(desiredState = true)
             }
 
             step("Toggle Mobile data") {
-                device.network.toggleMobileData(false)
+                device!!.network.toggleMobileData(false)
                 assertFalseSafely { isDataConnected() }
-                device.network.toggleMobileData(true)
+                device!!.network.toggleMobileData(true)
                 assertTrueSafely { isDataConnected() }
             }
         }
@@ -75,7 +75,7 @@ class DeviceNetworkSampleTest : TestCase() {
         if (currentOsVersion < Build.VERSION_CODES.N_MR1) isDataConnectedInLowAndroid() else isDataConnectedInHighAndroid()
 
     private fun BaseTestContext.isDataConnectedInHighAndroid(): Boolean {
-        val manager = device.context.getSystemService(ConnectivityManager::class.java) as ConnectivityManager
+        val manager = device!!.context.getSystemService(ConnectivityManager::class.java) as ConnectivityManager
         val cdl = CountDownLatch(1)
         var isConnected = false
 
@@ -106,11 +106,11 @@ class DeviceNetworkSampleTest : TestCase() {
 
     private fun BaseTestContext.isDataConnectedInLowAndroid(): Boolean {
         val telephonyManager: TelephonyManager? =
-            device.context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager?
+            device!!.context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager?
         if (telephonyManager?.simState != TelephonyManager.SIM_STATE_READY) {
             return false
         }
-        return Settings.Global.getInt(device.context.contentResolver, "mobile_data", 0) == 1
+        return Settings.Global.getInt(device!!.context.contentResolver, "mobile_data", 0) == 1
     }
 
     private fun BaseTestContext.checkWifi(desiredState: Boolean) {
@@ -126,6 +126,6 @@ class DeviceNetworkSampleTest : TestCase() {
     }
 
     private fun BaseTestContext.isWiFiEnabled(): Boolean =
-        (device.context.getSystemService(Context.WIFI_SERVICE) as? WifiManager)?.isWifiEnabled
+        (device!!.context.getSystemService(Context.WIFI_SERVICE) as? WifiManager)?.isWifiEnabled
             ?: throw IllegalStateException("WifiManager is unavailable")
 }

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DevicePermissionsSampleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DevicePermissionsSampleTest.kt
@@ -31,7 +31,7 @@ class DevicePermissionsSampleTest : TestCase() {
         assumeTrue(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
 
         before {
-            adbServer.performShell("pm revoke ${device.targetContext.packageName} ${Manifest.permission.READ_CALL_LOG}")
+            adbServer.performShell("pm revoke ${device!!.targetContext.packageName} ${Manifest.permission.READ_CALL_LOG}")
         }.after {
         }.run {
 
@@ -43,7 +43,7 @@ class DevicePermissionsSampleTest : TestCase() {
                     }
                 }
 
-                device.permissions.apply {
+                device!!.permissions.apply {
                     assertTrueSafely { isDialogVisible() }
                     allowViaDialog()
                 }
@@ -55,6 +55,6 @@ class DevicePermissionsSampleTest : TestCase() {
     }
 
     private fun BaseTestContext.hasCallLogPermission(): Boolean =
-        device.targetContext.checkSelfPermission(Manifest.permission.READ_CALL_LOG) ==
+        device!!.targetContext.checkSelfPermission(Manifest.permission.READ_CALL_LOG) ==
                 PackageManager.PERMISSION_GRANTED
 }

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DevicePhoneSampleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DevicePhoneSampleTest.kt
@@ -39,16 +39,16 @@ class DevicePhoneSampleTest : TestCase() {
         run {
 
             step("Emulate a call") {
-                device.phone.emulateCall(PHONE_NUMBER)
+                device!!.phone.emulateCall(PHONE_NUMBER)
                 Screen.idle(CALL_DURATION)
-                device.phone.cancelCall(PHONE_NUMBER)
+                device!!.phone.cancelCall(PHONE_NUMBER)
                 Screen.idle(CONTENT_UPDATE_DELAY)
 
                 assertEquals(PHONE_NUMBER, getLastCallPhoneNumber())
             }
 
             step("Receive SMS message") {
-                device.phone.receiveSms(
+                device!!.phone.receiveSms(
                     PHONE_NUMBER,
                     SMS_MESSAGE_TEXT
                 )
@@ -63,7 +63,7 @@ class DevicePhoneSampleTest : TestCase() {
     }
 
     private fun BaseTestContext.getLastCallPhoneNumber(): String? {
-        val cursor = device.targetContext.contentResolver.query(
+        val cursor = device!!.targetContext.contentResolver.query(
             CallLog.Calls.CONTENT_URI, null,
             null, null, CallLog.Calls.DATE + " DESC"
         )
@@ -78,7 +78,7 @@ class DevicePhoneSampleTest : TestCase() {
     }
 
     private fun BaseTestContext.getLastSmsInfo(): SmsInfo? {
-        val cursor = device.targetContext.contentResolver.query(
+        val cursor = device!!.targetContext.contentResolver.query(
             Telephony.Sms.Inbox.CONTENT_URI,
             arrayOf(Telephony.TextBasedSmsColumns.ADDRESS, Telephony.TextBasedSmsColumns.BODY),
             null,

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceScreenshotSampleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceScreenshotSampleTest.kt
@@ -39,7 +39,7 @@ class DeviceScreenshotSampleTest : TestCase() {
 
             step("Take a screenshot") {
                 assertFalse(screenshotExists())
-                device.screenshots.take(SCREENSHOT_TAG)
+                device!!.screenshots.take(SCREENSHOT_TAG)
                 assertTrue(screenshotExists())
             }
         }
@@ -54,7 +54,7 @@ class DeviceScreenshotSampleTest : TestCase() {
             Environment.getExternalStorageDirectory().resolve(dir)
         } else {
             // Use internal storage.
-            device.targetContext.getDir(dir.canonicalPath, Context.MODE_WORLD_READABLE)
+            device!!.targetContext.getDir(dir.canonicalPath, Context.MODE_WORLD_READABLE)
         }
     }
 

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceServerSampleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceServerSampleTest.kt
@@ -39,7 +39,7 @@ class DeviceServerSampleTest : TestCase() {
                 val command = "pm list packages"
 
                 val result = adbServer.performShell(command)
-                assertTrue("package:${device.targetContext.packageName}" in result.first())
+                assertTrue("package:${device!!.targetContext.packageName}" in result.first())
             }
         }
     }

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/docloc_tests/ChangeSysLanguageTestCase.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/docloc_tests/ChangeSysLanguageTestCase.kt
@@ -35,7 +35,7 @@ class ChangeSysLanguageTestCase : DocLocScreenshotTestCase(
         step("Start Android OS Settings") {
             val intent = Intent(Settings.ACTION_SETTINGS)
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            device.targetContext.startActivity(intent)
+            device!!.targetContext.startActivity(intent)
             Thread.sleep(3000)
         }
 

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/flaky_tests/UiCommonFlakyTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/flaky_tests/UiCommonFlakyTest.kt
@@ -51,7 +51,7 @@ class UiCommonFlakyTest : TestCase() {
                         // even UiAutomator is using under the hood =)
                         // the text is changing during 3 seconds
                         // the default value of flaky safety timeout = 10 seconds
-                        hasText(device.targetContext.getString(R.string.common_flaky_final_button).toUpperCase())
+                        hasText(device!!.targetContext.getString(R.string.common_flaky_final_button).toUpperCase())
                     }
                 }
             }
@@ -63,7 +63,7 @@ class UiCommonFlakyTest : TestCase() {
                         //     the default value of flaky safety timeout(10 seconds)
                         // that's why we use flakySafely method obviously
                         flakySafely(timeoutMs = 16_000) {
-                            hasText(device.targetContext.getString(R.string.common_flaky_final_textview))
+                            hasText(device!!.targetContext.getString(R.string.common_flaky_final_textview))
                         }
                     }
                 }

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/idlingwait_tests/WaitForIdleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/idlingwait_tests/WaitForIdleTest.kt
@@ -15,8 +15,7 @@ import org.junit.Test
 
 class WaitForIdleTest : TestCase(
     kaspressoBuilder = Kaspresso.Builder.simple {
-        kautomatorWaitForIdleSettings = KautomatorWaitForIdleSettings.boost()
-    }
+        kautomatorWaitForIdleSettings = KautomatorWaitForIdleSettings.boost() }
 ) {
 
     @get:Rule
@@ -46,7 +45,7 @@ class WaitForIdleTest : TestCase(
                 UiWaitForIdleScreen {
                     edit {
                         isDisplayed()
-                        containsText(device.targetContext.getString(R.string.idlewaiting_fragment_text_edittext))
+                        containsText(device!!.targetContext.getString(R.string.idlewaiting_fragment_text_edittext))
                     }
                 }
             }

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/measure_tests/KautomatorMeasureTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/measure_tests/KautomatorMeasureTest.kt
@@ -51,7 +51,7 @@ class KautomatorMeasureTest : TestCase(
                     RANGE.forEach { _ ->
                         button1 {
                             click()
-                            hasText(device.targetContext.getString(R.string.measure_fragment_text_button_1).toUpperCase())
+                            hasText(device!!.targetContext.getString(R.string.measure_fragment_text_button_1).toUpperCase())
                         }
                     }
                 }
@@ -62,11 +62,11 @@ class KautomatorMeasureTest : TestCase(
                     RANGE.forEach { index ->
                         button2 {
                             click()
-                            hasText(device.targetContext.getString(R.string.measure_fragment_text_button_2).toUpperCase())
+                            hasText(device!!.targetContext.getString(R.string.measure_fragment_text_button_2).toUpperCase())
                         }
                         textView {
                             hasText(
-                                "${device.targetContext.getString(R.string.measure_fragment_text_textview)}${index + 1}"
+                                "${device!!.targetContext.getString(R.string.measure_fragment_text_textview)}${index + 1}"
                             )
                         }
                     }
@@ -77,7 +77,7 @@ class KautomatorMeasureTest : TestCase(
                 UiMeasureScreen {
                     edit {
                         isDisplayed()
-                        hasText(device.targetContext.getString(R.string.measure_fragment_text_edittext))
+                        hasText(device!!.targetContext.getString(R.string.measure_fragment_text_edittext))
                         RANGE.forEach { _ ->
                             clearText()
                             typeText("bla-bla-bla")

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/simple_tests/SimpleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/simple_tests/SimpleTest.kt
@@ -36,7 +36,7 @@ class SimpleTest : TestCase() {
             step("Open Simple Screen") {
                 activityTestRule.launchActivity(null)
                 testLogger.i("I am testLogger")
-                device.screenshots.take("Additional_screenshot")
+                device!!.screenshots.take("Additional_screenshot")
                 MainScreen {
                     simpleButton {
                         isVisible()

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/simple_tests/SimpleTestWithRule.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/simple_tests/SimpleTestWithRule.kt
@@ -39,7 +39,7 @@ class SimpleTestWithRule {
             step("Open Simple Screen") {
                 testLogger.i("I am testLogger")
                 activityTestRule.launchActivity(null)
-                device.screenshots.take("Additional_screenshot")
+                device!!.screenshots.take("Additional_screenshot")
                 MainScreen {
                     simpleButton {
                         isVisible()

--- a/samples/kaspresso-sample/src/main/AndroidManifest.xml
+++ b/samples/kaspresso-sample/src/main/AndroidManifest.xml
@@ -73,6 +73,10 @@
             android:name=".idlingwait.WaitForIdleActivity"
             android:label="@string/main_screen_idlewaiting_sample_button"/>
 
+        <activity
+            android:name=".robolectric.RobolectricActivity"
+            android:label="@string/main_screen_robolectric"/>
+
         <service
             android:name=".device.DeviceSampleAccessibilityService"
             android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE"

--- a/samples/kaspresso-sample/src/main/AndroidManifest.xml
+++ b/samples/kaspresso-sample/src/main/AndroidManifest.xml
@@ -74,8 +74,8 @@
             android:label="@string/main_screen_idlewaiting_sample_button"/>
 
         <activity
-            android:name=".robolectric.RobolectricActivity"
-            android:label="@string/main_screen_robolectric"/>
+            android:name=".sharedtest.SharedTestActivity"
+            android:label="@string/main_screen_shared_test"/>
 
         <service
             android:name=".device.DeviceSampleAccessibilityService"

--- a/samples/kaspresso-sample/src/main/kotlin/com/kaspersky/kaspressample/robolectric/RobolectricActivity.kt
+++ b/samples/kaspresso-sample/src/main/kotlin/com/kaspersky/kaspressample/robolectric/RobolectricActivity.kt
@@ -1,0 +1,14 @@
+package com.kaspersky.kaspressample.robolectric
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.kaspersky.kaspressample.R
+
+class RobolectricActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_robolectric)
+    }
+}
+

--- a/samples/kaspresso-sample/src/main/kotlin/com/kaspersky/kaspressample/sharedtest/SharedTestActivity.kt
+++ b/samples/kaspresso-sample/src/main/kotlin/com/kaspersky/kaspressample/sharedtest/SharedTestActivity.kt
@@ -1,14 +1,14 @@
-package com.kaspersky.kaspressample.robolectric
+package com.kaspersky.kaspressample.sharedtest
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.kaspersky.kaspressample.R
 
-class RobolectricActivity : AppCompatActivity() {
+class SharedTestActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_robolectric)
+        setContentView(R.layout.activity_sharedtest)
     }
 }
 

--- a/samples/kaspresso-sample/src/main/res/layout/activity_robolectric.xml
+++ b/samples/kaspresso-sample/src/main/res/layout/activity_robolectric.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/scrollMe"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".nitrogen.NitrogenActivity">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <EditText
+            android:id="@+id/firstName"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="30dp"
+            android:hint="First Name"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/screenTitle" />
+
+        <EditText
+            android:id="@+id/lastName"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="20dp"
+            android:hint="Last name"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/firstName" />
+
+        <EditText
+            android:id="@+id/age"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="20dp"
+            android:layout_marginTop="20dp"
+            android:hint="Age"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/lastName" />
+
+        <TextView
+            android:id="@+id/gender"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="40dp"
+            android:layout_marginStart="20dp"
+            android:text="Gender"
+            android:textSize="20sp"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintBottom_toTopOf="@id/toggleButton"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/age" />
+
+        <com.google.android.material.button.MaterialButtonToggleGroup
+            android:id="@+id/toggleButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:layout_marginStart="20dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/gender"
+            app:singleSelection="true">
+
+            <Button
+                android:id="@+id/male"
+                style="?attr/materialButtonOutlinedStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Male" />
+
+            <Button
+                android:id="@+id/female"
+                style="?attr/materialButtonOutlinedStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Female" />
+        </com.google.android.material.button.MaterialButtonToggleGroup>
+
+        <TextView
+            android:id="@+id/screenTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="Hello first fragment"
+            android:textSize="20sp"
+            app:layout_constraintBottom_toTopOf="@id/firstName"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/firstText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:text="@string/large_text"
+            app:layout_constraintTop_toBottomOf="@id/toggleButton"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            />
+
+        <Button
+            android:id="@+id/findMeButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:layout_marginTop="50dp"
+            android:text="Find me"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/firstText"
+            />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>
+

--- a/samples/kaspresso-sample/src/main/res/layout/activity_sharedtest.xml
+++ b/samples/kaspresso-sample/src/main/res/layout/activity_sharedtest.xml
@@ -5,7 +5,7 @@
     android:id="@+id/scrollMe"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".nitrogen.NitrogenActivity">
+    tools:context=".sharedtest.SharedTestActivity">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -114,7 +114,7 @@
             android:layout_height="wrap_content"
             android:layout_margin="16dp"
             android:layout_marginTop="50dp"
-            android:text="Find me"
+            android:text="FIND ME"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/firstText"

--- a/samples/kaspresso-sample/src/main/res/values/strings.xml
+++ b/samples/kaspresso-sample/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="main_screen_complex_compose_sample_button">Complex compose sample</string>
     <string name="main_screen_idlewaiting_sample_button">Waiting for idle sample</string>
     <string name="main_screen_measure_sample_button">Measure sample</string>
-    <string name="main_screen_robolectric">Shared Test with Robolectric sample</string>
+    <string name="main_screen_shared_test">Shared Test with Robolectric sample</string>
 
     <!-- Simple fragment screen -->
     <string name="simple_fragment_title">Simple Fragment</string>

--- a/samples/kaspresso-sample/src/main/res/values/strings.xml
+++ b/samples/kaspresso-sample/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="main_screen_complex_compose_sample_button">Complex compose sample</string>
     <string name="main_screen_idlewaiting_sample_button">Waiting for idle sample</string>
     <string name="main_screen_measure_sample_button">Measure sample</string>
+    <string name="main_screen_robolectric">Shared Test with Robolectric sample</string>
 
     <!-- Simple fragment screen -->
     <string name="simple_fragment_title">Simple Fragment</string>
@@ -75,4 +76,93 @@
     <string name="idlewaiting_fragment_title" translatable="false">Wait for idle Fragment</string>
     <string name="idlewaiting_fragment_text_edittext" translatable="false">Some text</string>
 
+    <string name="large_text" translatable="false">
+        "Material is the metaphor.\n\n"
+
+        "A material metaphor is the unifying theory of a rationalized space and a system of motion."
+        "The material is grounded in tactile reality, inspired by the study of paper and ink, yet "
+        "technologically advanced and open to imagination and magic.\n"
+        "Surfaces and edges of the material provide visual cues that are grounded in reality. The "
+        "use of familiar tactile attributes helps users quickly understand affordances. Yet the "
+        "flexibility of the material creates new affordances that supercede those in the physical "
+        "world, without breaking the rules of physics.\n"
+        "The fundamentals of light, surface, and movement are key to conveying how objects move, "
+        "interact, and exist in space and in relation to each other. Realistic lighting shows "
+        "seams, divides space, and indicates moving parts.\n\n"
+
+        "Bold, graphic, intentional.\n\n"
+
+        "The foundational elements of print based design typography, grids, space, scale, color, "
+        "and use of imagery guide visual treatments. These elements do far more than please the "
+        "eye. They create hierarchy, meaning, and focus. Deliberate color choices, edge to edge "
+        "imagery, large scale typography, and intentional white space create a bold and graphic "
+        "interface that immerse the user in the experience.\n"
+        "An emphasis on user actions makes core functionality immediately apparent and provides "
+        "waypoints for the user.\n\n"
+
+        "Motion provides meaning.\n\n"
+
+        "Motion respects and reinforces the user as the prime mover. Primary user actions are "
+        "inflection points that initiate motion, transforming the whole design.\n"
+        "All action takes place in a single environment. Objects are presented to the user without "
+        "breaking the continuity of experience even as they transform and reorganize.\n"
+        "Motion is meaningful and appropriate, serving to focus attention and maintain continuity. "
+        "Feedback is subtle yet clear. Transitions are efﬁcient yet coherent.\n\n"
+
+        "3D world.\n\n"
+
+        "The material environment is a 3D space, which means all objects have x, y, and z "
+        "dimensions. The z-axis is perpendicularly aligned to the plane of the display, with the "
+        "positive z-axis extending towards the viewer. Every sheet of material occupies a single "
+        "position along the z-axis and has a standard 1dp thickness.\n"
+        "On the web, the z-axis is used for layering and not for perspective. The 3D world is "
+        "emulated by manipulating the y-axis.\n\n"
+
+        "Light and shadow.\n\n"
+
+        "Within the material environment, virtual lights illuminate the scene. Key lights create "
+        "directional shadows, while ambient light creates soft shadows from all angles.\n"
+        "Shadows in the material environment are cast by these two light sources. In Android "
+        "development, shadows occur when light sources are blocked by sheets of material at "
+        "various positions along the z-axis. On the web, shadows are depicted by manipulating the "
+        "y-axis only. The following example shows the card with a height of 6dp.\n\n"
+
+        "Resting elevation.\n\n"
+
+        "All material objects, regardless of size, have a resting elevation, or default elevation "
+        "that does not change. If an object changes elevation, it should return to its resting "
+        "elevation as soon as possible.\n\n"
+
+        "Component elevations.\n\n"
+
+        "The resting elevation for a component type is consistent across apps (e.g., FAB elevation "
+        "does not vary from 6dp in one app to 16dp in another app).\n"
+        "Components may have different resting elevations across platforms, depending on the depth "
+        "of the environment (e.g., TV has a greater depth than mobile or desktop).\n\n"
+
+        "Responsive elevation and dynamic elevation offsets.\n\n"
+
+        "Some component types have responsive elevation, meaning they change elevation in response "
+        "to user input (e.g., normal, focused, and pressed) or system events. These elevation "
+        "changes are consistently implemented using dynamic elevation offsets.\n"
+        "Dynamic elevation offsets are the goal elevation that a component moves towards, relative "
+        "to the component’s resting state. They ensure that elevation changes are consistent "
+        "across actions and component types. For example, all components that lift on press have "
+        "the same elevation change relative to their resting elevation.\n"
+        "Once the input event is completed or cancelled, the component will return to its resting "
+        "elevation.\n\n"
+
+        "Avoiding elevation interference.\n\n"
+
+        "Components with responsive elevations may encounter other components as they move between "
+        "their resting elevations and dynamic elevation offsets. Because material cannot pass "
+        "through other material, components avoid interfering with one another any number of ways, "
+        "whether on a per component basis or using the entire app layout.\n"
+        "On a component level, components can move or be removed before they cause interference. "
+        "For example, a floating action button (FAB) can disappear or move off screen before a "
+        "user picks up a card, or it can move if a snackbar appears.\n"
+        "On the layout level, design your app layout to minimize opportunities for interference. "
+        "For example, position the FAB to one side of stream of a cards so the FAB won’t interfere "
+        "when a user tries to pick up one of cards.\n\n"
+    </string>
 </resources>

--- a/samples/kaspresso-sample/src/sharedTest/kotlin/com.kaspersky.kaspressample.robolectric/RobolectricTest.kt
+++ b/samples/kaspresso-sample/src/sharedTest/kotlin/com.kaspersky.kaspressample.robolectric/RobolectricTest.kt
@@ -1,0 +1,111 @@
+package com.kaspersky.kaspressample.robolectric
+
+import androidx.test.ext.junit.rules.activityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.kaspersky.kaspressample.screen.RobolectricScreen
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.github.kakaocup.kakao.screen.Screen
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RobolectricTest : TestCase() {
+
+    @get:Rule
+    val activityRule = activityScenarioRule<RobolectricActivity>()
+
+    @Test
+    fun test() {
+        before {
+            activityRule.scenario
+        }.after {
+
+        }.run {
+            step("Fill info and find button") {
+                Screen.onScreen<RobolectricScreen> {
+                    writeFirstName("Sergio")
+                    writeLastName("Sastre Florez")
+                    writeAge("8")
+                    clickOnMale()
+                }
+            }
+            step("Check Info filled") {
+                Screen.onScreen<RobolectricScreen> {
+                    verifyFirstNameIs("Sergio")
+                }
+            }
+
+            step("Click on find button") {
+                Screen.onScreen<RobolectricScreen> {
+                    findMeButton {
+                        hasText("FIND ME")
+                    }
+                }
+            }
+        }
+    }
+
+
+    @Test
+    fun test3() {
+        before {
+            activityRule.scenario
+        }.after {
+
+        }.run {
+            step("Fill info and find button") {
+                Screen.onScreen<RobolectricScreen> {
+                    writeFirstName("Sergio")
+                    writeLastName("Sastre Florez")
+                    writeAge("8")
+                    clickOnMale()
+                }
+            }
+
+            step("Check Info filled") {
+                Screen.onScreen<RobolectricScreen> {
+                    verifyFirstNameIs("Sergio")
+                }
+            }
+
+            step("Click on find button") {
+                Screen.onScreen<RobolectricScreen> {
+                    clickOnFindMeButton()
+                }
+            }
+
+        }
+    }
+
+    @Test
+    fun test4() {
+        before {
+            activityRule.scenario
+        }.after {
+
+        }.run {
+            step("Fill info and find button") {
+                Screen.onScreen<RobolectricScreen> {
+                    writeFirstName("Sergio")
+                    writeLastName("Sastre Florez")
+                    writeAge("8")
+                    clickOnMale()
+                }
+            }
+
+            step("Check Info filled") {
+                Screen.onScreen<RobolectricScreen> {
+                    verifyFirstNameIs("Sergio")
+                }
+            }
+
+            step("Click on find button") {
+                Screen.onScreen<RobolectricScreen> {
+                    clickOnFindMeButton()
+                }
+            }
+        }
+    }
+}
+

--- a/samples/kaspresso-sample/src/sharedTest/kotlin/com.kaspersky.kaspressample.robolectric/RobolectricTest.kt
+++ b/samples/kaspresso-sample/src/sharedTest/kotlin/com.kaspersky.kaspressample.robolectric/RobolectricTest.kt
@@ -3,6 +3,8 @@ package com.kaspersky.kaspressample.robolectric
 import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.kaspersky.kaspressample.screen.RobolectricScreen
+import com.kaspersky.kaspresso.kaspresso.Kaspresso
+
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.kakao.screen.Screen
 import org.junit.Rule
@@ -10,7 +12,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class RobolectricTest : TestCase() {
+class RobolectricTest : TestCase(Kaspresso.Builder.simple(sharedTest = true)) {
 
     @get:Rule
     val activityRule = activityScenarioRule<RobolectricActivity>()
@@ -22,87 +24,38 @@ class RobolectricTest : TestCase() {
         }.after {
 
         }.run {
-            step("Fill info and find button") {
+            step("Fill info") {
                 Screen.onScreen<RobolectricScreen> {
-                    writeFirstName("Sergio")
-                    writeLastName("Sastre Florez")
-                    writeAge("8")
-                    clickOnMale()
-                }
-            }
-            step("Check Info filled") {
-                Screen.onScreen<RobolectricScreen> {
-                    verifyFirstNameIs("Sergio")
-                }
-            }
-
-            step("Click on find button") {
-                Screen.onScreen<RobolectricScreen> {
-                    findMeButton {
-                        hasText("FIND ME")
+                    firstNameEditText{
+                        replaceText("Kaspersky")
+                    }
+                    lastNameEditText{
+                        replaceText("Kaspresso")
+                    }
+                    ageEditText{
+                        replaceText("8")
+                    }
+                    maleButton{
+                        click()
                     }
                 }
             }
-        }
-    }
-
-
-    @Test
-    fun test3() {
-        before {
-            activityRule.scenario
-        }.after {
-
-        }.run {
-            step("Fill info and find button") {
+            step("Verify Full Name info") {
                 Screen.onScreen<RobolectricScreen> {
-                    writeFirstName("Sergio")
-                    writeLastName("Sastre Florez")
-                    writeAge("8")
-                    clickOnMale()
+                    firstNameEditText {
+                        hasText("Kaspersky")
+                    }
+                    lastNameEditText {
+                        hasText("Kaspresso")
+                    }
                 }
             }
 
-            step("Check Info filled") {
+            step("Click on find me button") {
                 Screen.onScreen<RobolectricScreen> {
-                    verifyFirstNameIs("Sergio")
-                }
-            }
-
-            step("Click on find button") {
-                Screen.onScreen<RobolectricScreen> {
-                    clickOnFindMeButton()
-                }
-            }
-
-        }
-    }
-
-    @Test
-    fun test4() {
-        before {
-            activityRule.scenario
-        }.after {
-
-        }.run {
-            step("Fill info and find button") {
-                Screen.onScreen<RobolectricScreen> {
-                    writeFirstName("Sergio")
-                    writeLastName("Sastre Florez")
-                    writeAge("8")
-                    clickOnMale()
-                }
-            }
-
-            step("Check Info filled") {
-                Screen.onScreen<RobolectricScreen> {
-                    verifyFirstNameIs("Sergio")
-                }
-            }
-
-            step("Click on find button") {
-                Screen.onScreen<RobolectricScreen> {
-                    clickOnFindMeButton()
+                    findMeButton {
+                        click()
+                    }
                 }
             }
         }

--- a/samples/kaspresso-sample/src/sharedTest/kotlin/com/kaspersky/kaspressample/screen/RobolectricScreen.kt
+++ b/samples/kaspresso-sample/src/sharedTest/kotlin/com/kaspersky/kaspressample/screen/RobolectricScreen.kt
@@ -4,7 +4,6 @@ import com.kaspersky.kaspressample.R
 import com.kaspersky.kaspressample.robolectric.RobolectricActivity
 import com.kaspersky.kaspresso.screens.KScreen
 import io.github.kakaocup.kakao.edit.KEditText
-import io.github.kakaocup.kakao.scroll.KScrollView
 import io.github.kakaocup.kakao.text.KButton
 
 class RobolectricScreen : KScreen<RobolectricScreen>() {
@@ -14,39 +13,9 @@ class RobolectricScreen : KScreen<RobolectricScreen>() {
 
     val findMeButton = KButton { withId(R.id.findMeButton) }
 
-    val scrollView = KScrollView { withId(R.id.scrollMe) }
-
     val firstNameEditText = KEditText { withId(R.id.firstName) }
     val lastNameEditText = KEditText { withId(R.id.lastName) }
     val ageEditText = KEditText { withId(R.id.age) }
 
     val maleButton = KButton { withId(R.id.male) }
-
-    fun writeFirstName(firstName: String) {
-        firstNameEditText.replaceText(firstName)
-    }
-
-    fun writeLastName(lastName: String) {
-        lastNameEditText.replaceText(lastName)
-    }
-
-    fun writeAge(age: String) {
-        ageEditText.replaceText(age)
-    }
-
-    fun clickOnMale() {
-        maleButton.click()
-    }
-
-    fun clickOnFindMeButton() {
-        findMeButton.click()
-    }
-
-    fun verifyFirstNameIs(firstName: String) {
-        firstNameEditText.hasText(firstName)
-    }
-
-    fun isButtonDisplayed() {
-        findMeButton.isDisplayed()
-    }
 }

--- a/samples/kaspresso-sample/src/sharedTest/kotlin/com/kaspersky/kaspressample/screen/RobolectricScreen.kt
+++ b/samples/kaspresso-sample/src/sharedTest/kotlin/com/kaspersky/kaspressample/screen/RobolectricScreen.kt
@@ -1,0 +1,52 @@
+package com.kaspersky.kaspressample.screen
+
+import com.kaspersky.kaspressample.R
+import com.kaspersky.kaspressample.robolectric.RobolectricActivity
+import com.kaspersky.kaspresso.screens.KScreen
+import io.github.kakaocup.kakao.edit.KEditText
+import io.github.kakaocup.kakao.scroll.KScrollView
+import io.github.kakaocup.kakao.text.KButton
+
+class RobolectricScreen : KScreen<RobolectricScreen>() {
+
+    override val layoutId: Int = R.layout.activity_robolectric
+    override val viewClass: Class<*> = RobolectricActivity::class.java
+
+    val findMeButton = KButton { withId(R.id.findMeButton) }
+
+    val scrollView = KScrollView { withId(R.id.scrollMe) }
+
+    val firstNameEditText = KEditText { withId(R.id.firstName) }
+    val lastNameEditText = KEditText { withId(R.id.lastName) }
+    val ageEditText = KEditText { withId(R.id.age) }
+
+    val maleButton = KButton { withId(R.id.male) }
+
+    fun writeFirstName(firstName: String) {
+        firstNameEditText.replaceText(firstName)
+    }
+
+    fun writeLastName(lastName: String) {
+        lastNameEditText.replaceText(lastName)
+    }
+
+    fun writeAge(age: String) {
+        ageEditText.replaceText(age)
+    }
+
+    fun clickOnMale() {
+        maleButton.click()
+    }
+
+    fun clickOnFindMeButton() {
+        findMeButton.click()
+    }
+
+    fun verifyFirstNameIs(firstName: String) {
+        firstNameEditText.hasText(firstName)
+    }
+
+    fun isButtonDisplayed() {
+        findMeButton.isDisplayed()
+    }
+}

--- a/samples/kaspresso-sample/src/sharedTest/kotlin/com/kaspersky/kaspressample/screen/SharedTestScreen.kt
+++ b/samples/kaspresso-sample/src/sharedTest/kotlin/com/kaspersky/kaspressample/screen/SharedTestScreen.kt
@@ -1,15 +1,15 @@
 package com.kaspersky.kaspressample.screen
 
 import com.kaspersky.kaspressample.R
-import com.kaspersky.kaspressample.robolectric.RobolectricActivity
+import com.kaspersky.kaspressample.sharedtest.SharedTestActivity
 import com.kaspersky.kaspresso.screens.KScreen
 import io.github.kakaocup.kakao.edit.KEditText
 import io.github.kakaocup.kakao.text.KButton
 
-class RobolectricScreen : KScreen<RobolectricScreen>() {
+class SharedTestScreen : KScreen<SharedTestScreen>() {
 
-    override val layoutId: Int = R.layout.activity_robolectric
-    override val viewClass: Class<*> = RobolectricActivity::class.java
+    override val layoutId: Int = R.layout.activity_sharedtest
+    override val viewClass: Class<*> = SharedTestActivity::class.java
 
     val findMeButton = KButton { withId(R.id.findMeButton) }
 

--- a/samples/kaspresso-sample/src/sharedTest/kotlin/com/kaspersky/kaspressample/sharedtest/SharedTest.kt
+++ b/samples/kaspresso-sample/src/sharedTest/kotlin/com/kaspersky/kaspressample/sharedtest/SharedTest.kt
@@ -1,10 +1,9 @@
-package com.kaspersky.kaspressample.robolectric
+package com.kaspersky.kaspressample.sharedtest
 
 import androidx.test.ext.junit.rules.activityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.kaspersky.kaspressample.screen.RobolectricScreen
+import com.kaspersky.kaspressample.screen.SharedTestScreen
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
-
 import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
 import io.github.kakaocup.kakao.screen.Screen
 import org.junit.Rule
@@ -12,20 +11,20 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class RobolectricTest : TestCase(Kaspresso.Builder.simple(sharedTest = true)) {
+class SharedTest : TestCase(Kaspresso.Builder.simple(sharedTest = true)) {
 
     @get:Rule
-    val activityRule = activityScenarioRule<RobolectricActivity>()
+    val activityRule = activityScenarioRule<SharedTestActivity>()
 
     @Test
     fun test() {
         before {
             activityRule.scenario
         }.after {
-
+            //no-op
         }.run {
             step("Fill info") {
-                Screen.onScreen<RobolectricScreen> {
+                Screen.onScreen<SharedTestScreen> {
                     firstNameEditText{
                         replaceText("Kaspersky")
                     }
@@ -40,8 +39,9 @@ class RobolectricTest : TestCase(Kaspresso.Builder.simple(sharedTest = true)) {
                     }
                 }
             }
+
             step("Verify Full Name info") {
-                Screen.onScreen<RobolectricScreen> {
+                Screen.onScreen<SharedTestScreen> {
                     firstNameEditText {
                         hasText("Kaspersky")
                     }
@@ -52,7 +52,7 @@ class RobolectricTest : TestCase(Kaspresso.Builder.simple(sharedTest = true)) {
             }
 
             step("Click on find me button") {
-                Screen.onScreen<RobolectricScreen> {
+                Screen.onScreen<SharedTestScreen> {
                     findMeButton {
                         click()
                     }

--- a/samples/kautomator-sample-app-upgrade/src/androidTest/java/com/kaspersky/kaspresso/upgradesample/common/UpdateManager.kt
+++ b/samples/kautomator-sample-app-upgrade/src/androidTest/java/com/kaspersky/kaspresso/upgradesample/common/UpdateManager.kt
@@ -10,9 +10,9 @@ object UpdateManager {
     private const val TIMEOUT = 5_000L
 
     fun BaseTestContext.installAndLaunchMainApp() {
-        device.apps.install(OLD_VERSION_FILE)
+        device!!.apps.install(OLD_VERSION_FILE)
 
-        with(device.targetContext) {
+        with(device!!.targetContext) {
             val intent = packageManager.getLaunchIntentForPackage(MAIN_APP_PACKAGE_ID)
             startActivity(intent)
         }
@@ -23,7 +23,7 @@ object UpdateManager {
     fun BaseTestContext.updateAndLaunchMainApp() {
         adbServer.performAdb("install -r $NEW_VERSION_FILE")
 
-        with(device.targetContext) {
+        with(device!!.targetContext) {
             val intent = packageManager.getLaunchIntentForPackage(MAIN_APP_PACKAGE_ID)
             startActivity(intent)
         }
@@ -32,6 +32,6 @@ object UpdateManager {
     }
 
     fun BaseTestContext.uninstallMainApp() {
-        device.apps.uninstallIfExists(MAIN_APP_PACKAGE_ID)
+        device!!.apps.uninstallIfExists(MAIN_APP_PACKAGE_ID)
     }
 }

--- a/samples/kautomator-sample-app-upgrade/src/androidTest/java/com/kaspersky/kaspresso/upgradesample/test/UpgradeTestSample.kt
+++ b/samples/kautomator-sample-app-upgrade/src/androidTest/java/com/kaspersky/kaspresso/upgradesample/test/UpgradeTestSample.kt
@@ -67,7 +67,7 @@ class UpgradeTestSample : TestCase() {
             }
 
             step("Press Home button") {
-                device.uiDevice.pressHome()
+                device!!.uiDevice.pressHome()
             }
 
             step("Upgrade the app and launch then") {

--- a/wiki/00_Home.md
+++ b/wiki/00_Home.md
@@ -17,6 +17,7 @@ If you are looking forward of a wiki for old versions then follow links: <br>
 [05. Device](./05_Device.md) <br>
 [06. AdbServer](./06_AdbServer.md) <br>
 [07. DocLoc](./07_DocLoc.md) <br>
+[08. Kaspresso tests running on the JVM with Robolectric](./08_Kaspresso-Robolectric.md) <br>
 
 ## References
 

--- a/wiki/08_Kaspresso-Robolectric.md
+++ b/wiki/08_Kaspresso-Robolectric.md
@@ -1,0 +1,92 @@
+# Kaspresso tests running on the JVM with Robolectric
+
+## Main purpose
+
+Since Robolectric 4.0, we can also run Espresso-like tests also on the JVM with Robolectric.
+That is part of the [Project nitrogen from Google](https://www.youtube.com/watch?v=-_kZC29sWAo) (which became Unified Test Platform), where they want to allow developers to write UI test once, and run them everywhere.
+
+However, if you try to run Kaspresso-like test extending TestCase on the JVM with Robolectric, you will get the following error:
+```
+java.lang.NullPointerException
+	at androidx.test.uiautomator.QueryController.<init>(QueryController.java:95)
+	at androidx.test.uiautomator.UiDevice.<init>(UiDevice.java:109)
+	at androidx.test.uiautomator.UiDevice.getInstance(UiDevice.java:261)
+	at com.kaspersky.kaspresso.kaspresso.Kaspresso$Builder.<init>(Kaspresso.kt:297)
+	at com.kaspersky.kaspresso.kaspresso.Kaspresso$Builder$Companion.simple(Kaspresso.kt:215)
+	...
+```
+That is because Robolectric is just compatible with Espresso and not with uiAutomator. Kaspresso initializes UiDevice by default, which is an UiAutomator dependency, resulting in such an error.
+
+In order to enable Kaspresso tests to run also on the JVM with Robolectric, apart from all the [configuration required for Robolectric](http://robolectric.org/blog/2018/10/25/robolectric-4-0/),
+the Kaspresso Builder of your test class needs to contain sharedTest = true
+
+```kotlin
+SharedTest : TestCase(Kaspresso.Builder.simple(sharedTest = true)){...}
+```
+
+In doing so, Kautomator dependencies making use of UiDevice will be either replaced with empty doubles or safely nullified. This also means, no adb-server possible either, as well as some other interceptors e.g. the "Close System Dialog interceptor"
+or Screens using Kautomator under the hood.
+
+
+## Usage
+To create a test that can run on a device/emulator and on the JVM, we recommend to create a `sharedTest` folder, and configure `sourceSets` in gradle accordingly, similar to what you can see under the `build.gradle.kts` :samples:kaspresso-sample
+
+```kotlin
+sourceSets {
+   ...
+   //configure shared test folder
+   val sharedTestFolder = "src/sharedTest/kotlin"
+   val androidTest by getting {
+       java.srcDirs("src/andoroidTest/java", sharedTestFolder )
+   }
+   val test by getting {
+       java.srcDirs("src/test/java", sharedTestFolder )
+   }
+}
+```
+
+It is also important that such tests use ``@RunWith(AndroidJUnit4::class)``, since it is required by Robolectric. 
+
+We also recommend not to define your Screens as `object` but as `class` instead, since we've observed some shared tests timing out otherwise.
+Prefer to define your Screens like this
+
+```kotlin
+class NitrogenFragmentScrollingScreen : KScreen<NitrogenFragmentScrollingScreen>() {
+...
+}
+```
+
+to this
+
+```kotlin
+object NitrogenFragmentScrollingScreen : KScreen<NitrogenFragmentScrollingScreen>() {
+...
+}
+```
+
+In order to run your shared tests as Unit test on the JVM, you need to run a command looking like this:
+```
+./gradlew :MODULE:connectedVARIANTAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=PACKAGE.CLASS
+```
+
+For example, to run the sample RobolectricTest on the JVM you need to run:
+```
+./gradlew :samples:kaspresso-sample:testDebugUnitTest --tests "com.kaspersky.kaspressample.sharedtest.SharedTest"
+```
+
+To run them on a device/emulator, the command to run would look like this:
+```
+./gradlew :MODULE:testVARIANTUnitTest --tests "PACKAGE.CLASS"
+```
+
+For instance, to run the sample NitrogenSharedTest on a device/emulator, you need to run:
+```
+./gradlew :samples:kaspresso-sample:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.kaspersky.kaspressample.sharedtest.SharedTest
+```
+
+
+**Further remarks**
+
+As of Robolectric 5.4.1, there are some limitations to sharedTest: those tests run flawless on an emulator/device, but fail on the JVM
+1) Robolectric-Espresso [does not support Idling resources](https://github.com/robolectric/robolectric/issues/4807) yet
+2) Robolectric-Espresso will not support [tests that start new activities](https://github.com/robolectric/robolectric/issues/5104)(i.e. activity jumping)


### PR DESCRIPTION
@eakurnikov @matzuk @RuslanMingaliev 
This PR replaces [this one](https://github.com/KasperskyLab/Kaspresso/pull/243)
Instead of duplicating classes, it enables to write tests that can run on the JVM through the Kaspresso.Builder