### PR TITLE
Fix logcat dump problems 

### DIFF
--- a/allure-support/src/main/kotlin/com/kaspersky/components/alluresupport/AllureSupportKaspressoBuilder.kt
+++ b/allure-support/src/main/kotlin/com/kaspersky/components/alluresupport/AllureSupportKaspressoBuilder.kt
@@ -21,9 +21,9 @@ fun Kaspresso.Builder.addAllureSupport(): Kaspresso.Builder = apply {
     )
     testRunWatcherInterceptors.addAll(
         listOf(
+            DumpLogcatTestInterceptor(logcatDumper),
             ScreenshotTestInterceptor(screenshots),
             VideoRecordingTestInterceptor(videos),
-            DumpLogcatTestInterceptor(logcatDumper),
             DumpViewsTestInterceptor(viewHierarchyDumper)
         )
     )

--- a/allure-support/src/main/kotlin/com/kaspersky/components/alluresupport/interceptors/testrun/DumpLogcatTestInterceptor.kt
+++ b/allure-support/src/main/kotlin/com/kaspersky/components/alluresupport/interceptors/testrun/DumpLogcatTestInterceptor.kt
@@ -9,6 +9,10 @@ class DumpLogcatTestInterceptor(
     private val logcatDumper: LogcatDumper
 ) : TestRunWatcherInterceptor {
 
+    override fun onTestStarted(testInfo: TestInfo) {
+        logcatDumper.watch()
+    }
+
     override fun onTestFinished(testInfo: TestInfo, success: Boolean) {
         logcatDumper.dumpAndApply("TestLogcat") { attachLogcatToAllureReport() }
     }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/accessibility/AccessibilityImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/accessibility/AccessibilityImpl.kt
@@ -5,11 +5,14 @@ import android.app.UiAutomation
 import android.os.Build
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.Configurator
+import com.kaspersky.kaspresso.logger.UiTestLogger
 
 /**
  * The implementation of the [Accessibility] interface.
  */
-class AccessibilityImpl : Accessibility {
+class AccessibilityImpl(
+    private val logger: UiTestLogger
+) : Accessibility {
 
     /**
      * Enables accessibility. Available since api 24.
@@ -29,6 +32,8 @@ class AccessibilityImpl : Accessibility {
             .getUiAutomation(UiAutomation.FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES)
             .executeShellCommand(cmd)
             .close()
+
+        logger.i("Accessibility service $packageName.$className enabled")
     }
 
     /**
@@ -43,5 +48,7 @@ class AccessibilityImpl : Accessibility {
             .getUiAutomation(UiAutomation.FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES)
             .executeShellCommand(cmd)
             .close()
+
+        logger.i("Accessibility services disabled")
     }
 }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/apps/AppsImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/apps/AppsImpl.kt
@@ -44,6 +44,7 @@ class AppsImpl(
      */
     override fun install(apkPath: String) {
         adbServer.performAdb("install $apkPath")
+        logger.i("App $apkPath installed")
     }
 
     /**
@@ -69,6 +70,7 @@ class AppsImpl(
      */
     override fun uninstall(packageName: String) {
         adbServer.performAdb("uninstall $packageName")
+        logger.i("App $packageName uninstalled")
     }
 
     /**
@@ -91,8 +93,7 @@ class AppsImpl(
      * @return a [Boolean] of installation state
      */
     override fun isInstalled(packageName: String): Boolean {
-        val packageManager = context.packageManager
-        if (packageManager == null) return false
+        val packageManager = context.packageManager ?: return false
         return try {
             packageManager.getApplicationInfo(packageName, 0)
             true
@@ -108,6 +109,7 @@ class AppsImpl(
         )
 
         val condition = Until.hasObject(By.pkg(launcherPackageName).depth(0))
+        logger.i("Wait $timeout for $launcherPackageName launch")
 
         Assert.assertTrue(
             uiDevice.wait(condition, timeout)
@@ -116,6 +118,7 @@ class AppsImpl(
 
     override fun waitForAppLaunchAndReady(timeout: Long, packageName: String) {
         val condition = Until.hasObject(By.pkg(packageName).depth(0))
+        logger.i("Wait $timeout for $packageName launch and ready")
 
         Assert.assertTrue(
             uiDevice.wait(condition, timeout)
@@ -160,6 +163,7 @@ class AppsImpl(
         }
 
         val condition = Until.hasObject(By.pkg(packageName).depth(0))
+        logger.i("Wait $LAUNCH_APP_TIMEOUT for $packageName launch")
 
         uiDevice.wait(condition, LAUNCH_APP_TIMEOUT)
     }
@@ -170,6 +174,7 @@ class AppsImpl(
      * @param contentDescription the description of the app to launch.
      */
     override fun openRecent(contentDescription: String) {
+        logger.i("Open $contentDescription from recents")
         uiDevice.pressRecentApps()
 
         val appSelector = UiSelector().descriptionContains(contentDescription)
@@ -191,5 +196,6 @@ class AppsImpl(
      */
     override fun kill(packageName: String) {
         Runtime.getRuntime().exec(arrayOf("am", "force-stop", packageName))
+        logger.i("Force stop $packageName")
     }
 }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/exploit/ExploitImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/exploit/ExploitImpl.kt
@@ -6,11 +6,13 @@ import androidx.test.espresso.Espresso
 import androidx.test.uiautomator.UiDevice
 import com.kaspersky.kaspresso.device.activities.Activities
 import com.kaspersky.kaspresso.device.server.AdbServer
+import com.kaspersky.kaspresso.logger.UiTestLogger
 
 /**
  * The implementation of the [Exploit] interface.
  */
 class ExploitImpl(
+    private val logger: UiTestLogger,
     private val activities: Activities,
     private val uiDevice: UiDevice,
     private val adbServer: AdbServer
@@ -30,6 +32,7 @@ class ExploitImpl(
             }
 
         setOrientation(neededDeviceOrientation)
+        logger.i("Device orientation set to $neededDeviceOrientation")
     }
 
     /**
@@ -50,6 +53,7 @@ class ExploitImpl(
         adbServer.performShell(
             "content insert --uri content://settings/system --bind name:s:user_rotation --bind value:i:$value"
         )
+        logger.i("Device orientation set to $deviceOrientation")
     }
 
     /**
@@ -65,6 +69,7 @@ class ExploitImpl(
         adbServer.performShell(
             "content insert --uri content://settings/system --bind name:s:accelerometer_rotation --bind value:i:$value"
         )
+        logger.i("Device auto rotation ${if (enabled) "en" else "dis"}abled")
     }
 
     /**
@@ -74,6 +79,7 @@ class ExploitImpl(
      * outside the application or process under test.
      */
     override fun pressBack(failTestIfAppUnderTestClosed: Boolean) {
+        logger.i("Press back button")
         if (failTestIfAppUnderTestClosed) {
             Espresso.pressBack()
         } else {
@@ -86,5 +92,8 @@ class ExploitImpl(
      *
      * @return true if successful, else return false.
      */
-    override fun pressHome(): Boolean = uiDevice.pressHome()
+    override fun pressHome(): Boolean {
+        logger.i("Press home button")
+        return uiDevice.pressHome()
+    }
 }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/files/FilesImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/files/FilesImpl.kt
@@ -1,11 +1,13 @@
 package com.kaspersky.kaspresso.device.files
 
 import com.kaspersky.kaspresso.device.server.AdbServer
+import com.kaspersky.kaspresso.logger.UiTestLogger
 
 /**
  * The implementation of the [Files] interface.
  */
 class FilesImpl(
+    private val logger: UiTestLogger,
     private val adbServer: AdbServer
 ) : Files {
 
@@ -19,6 +21,7 @@ class FilesImpl(
      */
     override fun push(serverPath: String, devicePath: String) {
         adbServer.performAdb("push $serverPath $devicePath")
+        logger.i("Push file from $serverPath to $devicePath")
     }
 
     /**
@@ -30,6 +33,7 @@ class FilesImpl(
      */
     override fun remove(path: String) {
         adbServer.performShell("rm -f $path")
+        logger.i("Remove file from $path")
     }
 
     /**
@@ -42,5 +46,6 @@ class FilesImpl(
      */
     override fun pull(devicePath: String, serverPath: String) {
         adbServer.performAdb("pull $devicePath $serverPath")
+        logger.i("Pull file from $devicePath to $serverPath")
     }
 }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/keyboard/KeyboardImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/keyboard/KeyboardImpl.kt
@@ -5,11 +5,13 @@ import androidx.test.espresso.action.ViewActions
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject
 import com.kaspersky.kaspresso.device.server.AdbServer
+import com.kaspersky.kaspresso.logger.UiTestLogger
 
 /**
  * The implementation of the [Keyboard] interface.
  */
 class KeyboardImpl(
+    private val logger: UiTestLogger,
     private val adbServer: AdbServer
 ) : Keyboard {
 
@@ -23,6 +25,7 @@ class KeyboardImpl(
      * Required Permissions: INTERNET
      */
     override fun typeText(text: String) {
+        logger.i("Type text $text")
         /*
          * Splits the text into characters and type them one by one
          * to prevent missing characters in the input field caused by very fast typing speed
@@ -44,6 +47,7 @@ class KeyboardImpl(
      * @param keyEvent the code from a [KeyEvent] constant to send on device.
      */
     override fun sendEvent(keyEvent: Int) {
+        logger.i("Send key event $keyEvent")
         adbServer.performShell("input keyevent $keyEvent")
     }
 }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/locales/Locales.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/locales/Locales.kt
@@ -25,6 +25,7 @@ internal class Locales(
      * @return set of supported locales.
      */
     fun getSupportedLocales(): Set<Locale> {
+        logger.i("Getting supported locales")
         return parseLocales(getLocaleString())
     }
 

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/location/LocationImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/location/LocationImpl.kt
@@ -1,11 +1,13 @@
 package com.kaspersky.kaspresso.device.location
 
 import com.kaspersky.kaspresso.device.server.AdbServer
+import com.kaspersky.kaspresso.logger.UiTestLogger
 
 /**
  * The implementation of the [Location] interface.
  */
 class LocationImpl(
+    private val logger: UiTestLogger,
     private val adbServer: AdbServer
 ) : Location {
 
@@ -16,6 +18,7 @@ class LocationImpl(
      */
     override fun enableGps() {
         setLocationProviders("+gps")
+        logger.i("GPS enabled")
     }
 
     /**
@@ -25,6 +28,7 @@ class LocationImpl(
      */
     override fun disableGps() {
         setLocationProviders("-gps")
+        logger.i("GPS disabled")
     }
 
     /**
@@ -34,6 +38,7 @@ class LocationImpl(
      */
     override fun setLocation(lat: Double, lon: Double) {
         adbServer.performAdb("emu geo fix $lon $lat") // geo fix uses Lon-Lat, almost everyone uses Lat-Lon
+        logger.i("Location set to $lat,$lon")
     }
 
     private fun setLocationProviders(providers: String) {

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/logcat/Logcat.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/logcat/Logcat.kt
@@ -41,6 +41,7 @@ interface Logcat {
     fun dumpLogcat(
         file: File,
         tags: List<String>? = null,
+        timeFrom: String? = null,
         excludePattern: String? = null,
         excludePatternIsIgnoreCase: Boolean = false,
         includePattern: String? = null,

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/logcat/LogcatImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/logcat/LogcatImpl.kt
@@ -7,6 +7,7 @@ import java.io.File
 import java.io.InputStreamReader
 
 class LogcatImpl(
+    private val logger: UiTestLogger,
     private val adbServer: AdbServer,
     private val isNeededToPrintExecutedCommand: Boolean = false,
     private val defaultBufferSize: LogcatBufferSize = LogcatBufferSize(DEFAULT_BUFFER_SIZE, LogcatBufferSize.Dimension.KILOBYTES)
@@ -63,6 +64,7 @@ class LogcatImpl(
     override fun dumpLogcat(
         file: File,
         tags: List<String>?,
+        timeFrom: String?,
         excludePattern: String?,
         excludePatternIsIgnoreCase: Boolean,
         includePattern: String?,
@@ -71,6 +73,7 @@ class LogcatImpl(
     ) {
         val command = prepareCommand(
             tags = tags,
+            timeFrom = timeFrom,
             excludePattern = excludePattern,
             excludePatternIsIgnoreCase = excludePatternIsIgnoreCase,
             includePattern = includePattern,
@@ -148,6 +151,7 @@ class LogcatImpl(
     ): Boolean {
         val command = prepareCommand(
             tags = null,
+            timeFrom = null,
             excludePattern = excludePattern,
             excludePatternIsIgnoreCase = excludePatternIsIgnoreCase,
             includePattern = includePattern,
@@ -225,6 +229,7 @@ class LogcatImpl(
      */
     private fun prepareCommand(
         tags: List<String>?,
+        timeFrom: String?,
         excludePattern: String?,
         excludePatternIsIgnoreCase: Boolean,
         includePattern: String?,
@@ -233,6 +238,9 @@ class LogcatImpl(
         rowLimit: Int?
     ): String {
         var command = "logcat -b ${buffer.bufferName} -d "
+        if (!timeFrom.isNullOrEmpty()) {
+            command += "-t \"$timeFrom\" "
+        }
         if (rowLimit != null && rowLimit > 0) {
             command += "-m $rowLimit "
         }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/logcat/dumper/LogcatDumper.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/logcat/dumper/LogcatDumper.kt
@@ -4,6 +4,8 @@ import java.io.File
 
 interface LogcatDumper {
 
+    fun watch()
+
     /**
      * Dumps logcat output with specific tag.
      */

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/logcat/dumper/LogcatDumperImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/logcat/dumper/LogcatDumperImpl.kt
@@ -5,6 +5,9 @@ import com.kaspersky.kaspresso.device.logcat.Logcat
 import com.kaspersky.kaspresso.files.resources.ResourceFilesProvider
 import com.kaspersky.kaspresso.logger.UiTestLogger
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class LogcatDumperImpl(
     private val logger: UiTestLogger,
@@ -12,6 +15,14 @@ class LogcatDumperImpl(
     private val logcat: Logcat,
     private val loggerTags: List<String>
 ) : LogcatDumper {
+
+    private val dateTimeFormat = SimpleDateFormat("MM-dd HH:mm:ss.SSS", Locale.getDefault())
+    private var timeDumpFrom: String? = null
+
+    override fun watch() {
+        timeDumpFrom = dateTimeFormat.format(Date())
+        logger.i("Logcat buffer may be dumped from $timeDumpFrom")
+    }
 
     override fun dump(tag: String): Unit = doDump(tag, null)
 
@@ -23,9 +34,9 @@ class LogcatDumperImpl(
             logcat.apply {
                 dumpLogcat(
                     file = logcatFile,
-                    tags = loggerTags
+                    tags = loggerTags,
+                    timeFrom = timeDumpFrom
                 )
-                clear()
             }
             block?.invoke(logcatFile)
         } catch (e: Throwable) {

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/network/NetworkImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/network/NetworkImpl.kt
@@ -22,9 +22,9 @@ import com.kaspersky.kaspresso.params.FlakySafetyParams
  * The implementation of the [Network] interface.
  */
 class NetworkImpl(
+    private val logger: UiTestLogger,
     private val targetContext: Context,
-    private val adbServer: AdbServer,
-    logger: UiTestLogger
+    private val adbServer: AdbServer
 ) : Network {
 
     companion object {
@@ -60,6 +60,7 @@ class NetworkImpl(
     override fun enable() {
         toggleMobileData(true)
         toggleWiFi(true)
+        logger.i("Enable wi-fi and mobile data")
     }
 
     /**
@@ -70,6 +71,7 @@ class NetworkImpl(
     override fun disable() {
         toggleMobileData(false)
         toggleWiFi(false)
+        logger.i("Disable wi-fi and mobile data")
     }
 
     /**
@@ -77,11 +79,12 @@ class NetworkImpl(
      * Settings then.
      */
     override fun toggleMobileData(enable: Boolean) {
-        if (
-            !toggleMobileDataUsingAdbServer(enable, NETWORK_STATE_CHANGE_ROOT_CMD) &&
+        if (!toggleMobileDataUsingAdbServer(enable, NETWORK_STATE_CHANGE_ROOT_CMD) &&
             !toggleMobileDataUsingAdbServer(enable, NETWORK_STATE_CHANGE_CMD)
-        )
-            return toggleMobileDataUsingAndroidSettings(enable)
+        ) {
+            toggleMobileDataUsingAndroidSettings(enable)
+            logger.i("Mobile data ${if (enable) "en" else "dis"}abled")
+        }
     }
 
     private fun toggleMobileDataUsingAdbServer(enable: Boolean, changeCommand: String): Boolean =
@@ -152,12 +155,13 @@ class NetworkImpl(
      * to switch Wi-Fi setting thumb.
      */
     override fun toggleWiFi(enable: Boolean) {
-        if (
-            !changeWiFiStateUsingAndroidApi(enable) &&
+        if (!changeWiFiStateUsingAndroidApi(enable) &&
             !changeWiFiStateUsingAdbServer(enable, WIFI_STATE_CHANGE_ROOT_CMD) &&
             !changeWiFiStateUsingAdbServer(enable, WIFI_STATE_CHANGE_CMD)
-        )
+        ) {
             changeWifiStateUsingAndroidSettings(enable)
+            logger.i("Wi-fi ${if (enable) "en" else "dis"}abled")
+        }
     }
 
     /**

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/permissions/PermissionsImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/permissions/PermissionsImpl.kt
@@ -37,32 +37,58 @@ class PermissionsImpl(
     /**
      * Waits for 1 sec, passes the permission-requesting permissions dialog and allows permissions.
      */
-    override fun allowViaDialog() =
-        wait(timeoutMs = DIALOG_TIMEOUT_MS, logger = logger) { handlePermissionRequest(Permissions.Button.ALLOW) }
+    override fun allowViaDialog() {
+        wait(
+            timeoutMs = DIALOG_TIMEOUT_MS,
+            logger = logger
+        ) {
+            handlePermissionRequest(Permissions.Button.ALLOW)
+        }
+        logger.i("Allow permission via dialog")
+    }
 
     /**
      * Waits for 1 sec, passes the permission-requesting permissions dialog and denies permissions.
      */
-    override fun denyViaDialog() =
-        wait(timeoutMs = DIALOG_TIMEOUT_MS, logger = logger) { handlePermissionRequest(Permissions.Button.DENY) }
+    override fun denyViaDialog() {
+        wait(
+            timeoutMs = DIALOG_TIMEOUT_MS,
+            logger = logger
+        ) {
+            handlePermissionRequest(Permissions.Button.DENY)
+        }
+        logger.i("Deny permission via dialog")
+    }
 
     /**
      * Waits for 1 sec, passes the permission-requesting permissions dialog
      */
-    override fun clickOn(button: Permissions.Button) =
-        wait(timeoutMs = DIALOG_TIMEOUT_MS, logger = logger) { handlePermissionRequest(button) }
+    override fun clickOn(button: Permissions.Button) {
+        wait(
+            timeoutMs = DIALOG_TIMEOUT_MS,
+            logger = logger
+        ) {
+            handlePermissionRequest(button)
+        }
+        logger.i("Apply $button for permission via dialog")
+    }
 
     /**
      * Waits for 1 sec, check the permission-requesting permissions dialog is visible.
      */
-    override fun isDialogVisible(): Boolean =
-        wait(timeoutMs = DIALOG_TIMEOUT_MS, logger = logger) {
+    override fun isDialogVisible(): Boolean {
+        logger.i("Check if permission dialog is visible")
+        return wait(
+            timeoutMs = DIALOG_TIMEOUT_MS,
+            logger = logger
+        ) {
             return@wait getPermissionDialogButtonAsUiObject(Permissions.Button.ALLOW)
                 ?.exists()
                 ?: getPermissionDialogButtonAsUiObject(Permissions.Button.DENY)
                     ?.exists()
                 ?: false
         }
+    }
 
     /**
      * Passes the permission-requesting permissions dialog.

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/phone/PhoneImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/phone/PhoneImpl.kt
@@ -1,11 +1,13 @@
 package com.kaspersky.kaspresso.device.phone
 
 import com.kaspersky.kaspresso.device.server.AdbServer
+import com.kaspersky.kaspresso.logger.UiTestLogger
 
 /**
  * The implementation of the [Phone] interface.
  */
 class PhoneImpl(
+    private val logger: UiTestLogger,
     private val adbServer: AdbServer
 ) : Phone {
 
@@ -15,6 +17,7 @@ class PhoneImpl(
      * Required Permissions: INTERNET
      */
     override fun emulateCall(number: String) {
+        logger.i("Emulate incoming call from $number")
         adbServer.performAdb("emu gsm call $number")
     }
 
@@ -24,6 +27,7 @@ class PhoneImpl(
      * Required Permissions: INTERNET
      */
     override fun cancelCall(number: String) {
+        logger.i("Cancel incoming call from $number")
         adbServer.performAdb("emu gsm cancel $number")
     }
 
@@ -33,6 +37,7 @@ class PhoneImpl(
      * Required Permissions: INTERNET
      */
     override fun receiveSms(number: String, text: String) {
+        logger.i("Emulate receiving an sms from $number")
         adbServer.performAdb("emu sms send $number $text")
     }
 }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/screenshots/ScreenshotsImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/screenshots/ScreenshotsImpl.kt
@@ -33,6 +33,7 @@ class ScreenshotsImpl(
             val screenshotFile: File = resourceFilesProvider.provideScreenshotFile(tag)
             screenshotMaker.takeScreenshot(screenshotFile)
             block?.invoke(screenshotFile)
+            logger.i("Screenshot saved to $screenshotFile")
         } catch (e: Throwable) {
             logger.e("An error while making screenshot occurred: ${Log.getStackTraceString(e)}")
         }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/video/VideosImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/video/VideosImpl.kt
@@ -2,9 +2,11 @@ package com.kaspersky.kaspresso.device.video
 
 import com.kaspersky.kaspresso.device.video.recorder.VideoRecorder
 import com.kaspersky.kaspresso.files.resources.ResourceFilesProvider
+import com.kaspersky.kaspresso.logger.UiTestLogger
 import java.io.File
 
 class VideosImpl(
+    private val logger: UiTestLogger,
     private val resourceFilesProvider: ResourceFilesProvider,
     private val videoRecorder: VideoRecorder
 ) : Videos {
@@ -15,10 +17,15 @@ class VideosImpl(
     }
 
     override fun save() {
-        videoRecorder.stop()
+        videoRecorder.stop()?.also { videoFile: File ->
+            logger.i("Video saved to $videoFile")
+        }
     }
 
     override fun saveAndApply(block: File.() -> Unit) {
-        videoRecorder.stop()?.apply { block(this) }
+        videoRecorder.stop()?.also { videoFile: File ->
+            block(videoFile)
+            logger.i("Video saved to $videoFile")
+        }
     }
 }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/viewhierarchy/ViewHierarchyDumperImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/viewhierarchy/ViewHierarchyDumperImpl.kt
@@ -7,7 +7,7 @@ import com.kaspersky.kaspresso.logger.UiTestLogger
 import java.io.File
 
 class ViewHierarchyDumperImpl(
-    private val device: UiDevice,
+    private val uiDevice: UiDevice,
     private val logger: UiTestLogger,
     private val resourceFilesProvider: ResourceFilesProvider
 ) : ViewHierarchyDumper {
@@ -18,9 +18,10 @@ class ViewHierarchyDumperImpl(
 
     private fun doDumpAndApply(tag: String, block: (File.() -> Unit)?) {
         try {
-            val logcatFile: File = resourceFilesProvider.provideViewHierarchyFile(tag)
-            device.dumpWindowHierarchy(logcatFile)
-            block?.invoke(logcatFile)
+            val viewHierarchyFile: File = resourceFilesProvider.provideViewHierarchyFile(tag)
+            uiDevice.dumpWindowHierarchy(viewHierarchyFile)
+            block?.invoke(viewHierarchyFile)
+            logger.i("View hierarchy dumped to $viewHierarchyFile")
         } catch (e: Throwable) {
             logger.e("View hierarchy dumping error occurred: ${Log.getStackTraceString(e)}")
         }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/interceptors/watcher/testcase/impl/logging/DumpLogcatInterceptor.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/interceptors/watcher/testcase/impl/logging/DumpLogcatInterceptor.kt
@@ -8,6 +8,10 @@ class DumpLogcatInterceptor(
     private val logcatDumper: LogcatDumper
 ) : TestRunWatcherInterceptor {
 
+    override fun onTestStarted(testInfo: TestInfo) {
+        logcatDumper.watch()
+    }
+
     override fun onTestFinished(testInfo: TestInfo, success: Boolean) {
         logcatDumper.dump("TestLogcat")
     }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/kaspresso/Kaspresso.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/kaspresso/Kaspresso.kt
@@ -284,9 +284,9 @@ data class Kaspresso(
                     )
                     testRunWatcherInterceptors.addAll(
                         listOf(
+                            DumpLogcatInterceptor(logcatDumper),
                             TestRunnerScreenshotWatcherInterceptor(screenshots),
                             VideoRecordingInterceptor(videos),
-                            DumpLogcatInterceptor(logcatDumper),
                             DumpViewsInterceptor(viewHierarchyDumper)
                         )
                     )
@@ -667,17 +667,17 @@ data class Kaspresso(
             if (!::adbServer.isInitialized) adbServer = AdbServerImpl(LogLevel.WARN, libLogger)
             if (!::apps.isInitialized) apps = AppsImpl(libLogger, instrumentation.context, uiDevice, adbServer)
             if (!::activities.isInitialized) activities = ActivitiesImpl(libLogger)
-            if (!::files.isInitialized) files = FilesImpl(adbServer)
-            if (!::network.isInitialized) network = NetworkImpl(instrumentation.targetContext, adbServer, libLogger)
-            if (!::phone.isInitialized) phone = PhoneImpl(adbServer)
-            if (!::location.isInitialized) location = LocationImpl(adbServer)
-            if (!::keyboard.isInitialized) keyboard = KeyboardImpl(adbServer)
-            if (!::accessibility.isInitialized) accessibility = AccessibilityImpl()
+            if (!::files.isInitialized) files = FilesImpl(libLogger, adbServer)
+            if (!::network.isInitialized) network = NetworkImpl(libLogger, instrumentation.targetContext, adbServer)
+            if (!::phone.isInitialized) phone = PhoneImpl(libLogger, adbServer)
+            if (!::location.isInitialized) location = LocationImpl(libLogger, adbServer)
+            if (!::keyboard.isInitialized) keyboard = KeyboardImpl(libLogger, adbServer)
+            if (!::accessibility.isInitialized) accessibility = AccessibilityImpl(libLogger)
             if (!::permissions.isInitialized) permissions = PermissionsImpl(libLogger, uiDevice)
             if (!::hackPermissions.isInitialized) hackPermissions = HackPermissionsImpl(instrumentation.uiAutomation, libLogger)
-            if (!::exploit.isInitialized) exploit = ExploitImpl(activities, uiDevice, adbServer)
+            if (!::exploit.isInitialized) exploit = ExploitImpl(libLogger, activities, uiDevice, adbServer)
             if (!::language.isInitialized) language = LanguageImpl(libLogger, instrumentation.targetContext)
-            if (!::logcat.isInitialized) logcat = LogcatImpl(adbServer)
+            if (!::logcat.isInitialized) logcat = LogcatImpl(libLogger, adbServer)
 
             if (!::flakySafetyParams.isInitialized) flakySafetyParams = FlakySafetyParams.default()
             if (!::continuouslyParams.isInitialized) continuouslyParams = ContinuouslyParams.default()
@@ -699,6 +699,7 @@ data class Kaspresso(
 
             if (!::videos.isInitialized) {
                 videos = VideosImpl(
+                    logger = libLogger,
                     resourceFilesProvider = resourceFilesProvider,
                     videoRecorder = VideoRecorderImpl(
                         uiDevice,

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/TestRunner.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/core/TestRunner.kt
@@ -43,6 +43,7 @@ internal class TestRunner<InitData, Data>(
         var testPassed = true
 
         try {
+            kaspresso.libLogger.line()
             testRunWatcherInterceptor.onTestStarted(testInfo)
 
             val data: Data = runBeforeTestSection(
@@ -84,6 +85,7 @@ internal class TestRunner<InitData, Data>(
                 resultException = exceptions.getException()
                 testInfo = testInfo.copy(throwable = resultException)
                 testRunWatcherInterceptor.onTestFinished(testInfo, testPassed)
+                kaspresso.libLogger.line()
                 kaspresso.adbServer.disconnectServer()
                 kaspresso.reset()
             }

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/simple_tests/CustomizedSimpleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/simple_tests/CustomizedSimpleTest.kt
@@ -69,9 +69,9 @@ class CustomizedSimpleTest : TestCase(
             clear()
             addAll(
                 listOf(
+                    DumpLogcatInterceptor(logcatDumper),
                     TestRunnerScreenshotWatcherInterceptor(screenshots),
                     VideoRecordingInterceptor(videos),
-                    DumpLogcatInterceptor(logcatDumper),
                     DumpViewsInterceptor(viewHierarchyDumper),
                     object : TestRunWatcherInterceptor {
                         override fun onTestFinished(testInfo: TestInfo, success: Boolean) {


### PR DESCRIPTION
Fixes #274

Добавил флаг -t к команде adb logcat, дампаю логкат после времени старта теста, теперь все дампается корректно, насколько я это смог проверить.

Больше не использую Logcat#clear, поэтому вернул там реализацию на adbServer, и в целом использование adbServer там не заменял на вызов shell с девайса, потому что регресс нужно проводить. Оставил все так, как работает сейчас, жалоб не было.

И насыпал там логов в device имплементации, мы почему-то не писали там ничего в лог.