### PR TITLE
Fix AllureLifecycle changes with 2.4.0 update

### DIFF
--- a/allure-support/src/main/kotlin/com/kaspersky/components/alluresupport/interceptors/step/AllureMapperStepInterceptor.kt
+++ b/allure-support/src/main/kotlin/com/kaspersky/components/alluresupport/interceptors/step/AllureMapperStepInterceptor.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 
 class AllureMapperStepInterceptor : StepWatcherInterceptor {
 
-    private val lifecycle = AllureAndroidLifecycle
+    private val lifecycle = AllureAndroidLifecycle()
 
     private val uuids: Stack<String> = Stack()
 


### PR DESCRIPTION
Object changed to class so we need to initialise it here

Without it I receive this crash:

```
java.lang.NoSuchFieldError: No static field INSTANCE of type Lio/qameta/allure/android/AllureAndroidLifecycle; in class Lio/qameta/allure/android/AllureAndroidLifecycle; or its superclasses (declaration of 'io.qameta.allure.android.AllureAndroidLifecycle' appears in /data/app/app.debug.test-YeU-HujJ37wRXVekeu2sPw==/base.apk)
at com.kaspersky.components.alluresupport.interceptors.step.AllureMapperStepInterceptor.<init>(AllureMapperStepInterceptor.kt:13)
at app.AllureSupportKaspressoBuilderKt.addAllureSupport(AllureSupportKaspressoBuilder.kt:32)
at app.AllureSupportKaspressoBuilderKt.withAllureSupport(AllureSupportKaspressoBuilder.kt:19)
```