### PR TITLE
Resolve issue #400

### DIFF
--- a/allure-support/src/main/kotlin/com/kaspersky/components/alluresupport/interceptors/step/AllureMapperStepInterceptor.kt
+++ b/allure-support/src/main/kotlin/com/kaspersky/components/alluresupport/interceptors/step/AllureMapperStepInterceptor.kt
@@ -2,7 +2,7 @@ package com.kaspersky.components.alluresupport.interceptors.step
 
 import com.kaspersky.kaspresso.interceptors.watcher.testcase.StepWatcherInterceptor
 import com.kaspersky.kaspresso.testcases.models.info.StepInfo
-import io.qameta.allure.android.AllureAndroidLifecycle
+import io.qameta.allure.kotlin.Allure
 import io.qameta.allure.kotlin.model.Status
 import io.qameta.allure.kotlin.model.StepResult
 import java.util.Stack
@@ -10,7 +10,7 @@ import java.util.UUID
 
 class AllureMapperStepInterceptor : StepWatcherInterceptor {
 
-    private val lifecycle = AllureAndroidLifecycle()
+    private val lifecycle = Allure.lifecycle
 
     private val uuids: Stack<String> = Stack()
 


### PR DESCRIPTION
# Source issue
#400 
# Problem
Steps are not recorded in report because new lifecycle is created so it differs from one used in `io.qameta.allure.android.runners.AllureAndroidJUnitRunner`
# Solution
- Use already instantiated lifecycle. It has been created when runner was initialized and saved to `Allure.lifecycle` property (see [AllureAndroidJUnitRunners.kt](https://github.com/allure-framework/allure-kotlin/blob/16cc20bd274ed7e19ba22d25758b9e70d2991662/allure-kotlin-android/src/main/kotlin/io/qameta/allure/android/runners/AllureAndroidJUnitRunners.kt#L80) for details).
- Similar approach is used in [ScreenshotStepInterceptor.kt](https://github.com/KasperskyLab/Kaspresso/blob/master/allure-support/src/main/kotlin/com/kaspersky/components/alluresupport/interceptors/step/ScreenshotStepInterceptor.kt). You can mention that after succeeded run of [AllureSupportTest](https://github.com/KasperskyLab/Kaspresso/blob/master/samples/kaspresso-allure-support-sample/src/androidTest/kotlin/com/kaspersky/kaspresso/alluresupport/sample/AllureSupportTest.kt) screenshots are saved. It has happened because runners lifecycle reused: 
https://github.com/KasperskyLab/Kaspresso/blob/cdba90ed292cf1107ebc4810dcfa81f295545c8d/allure-support/src/main/kotlin/com/kaspersky/components/alluresupport/interceptors/step/ScreenshotStepInterceptor.kt#L21
https://github.com/KasperskyLab/Kaspresso/blob/cdba90ed292cf1107ebc4810dcfa81f295545c8d/allure-support/src/main/kotlin/com/kaspersky/components/alluresupport/files/AttachToReport.kt#L20
# Demo
<img width="1728" alt="Снимок экрана 2022-10-28 в 17 51 21" src="https://user-images.githubusercontent.com/30111481/198659093-aebdc74a-a6a5-4ccb-b905-57088babfa68.png">