### PR TITLE
#407: Fix folder was created instead of video file

### DIFF
--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/files/resources/impl/DefaultResourceFilesProvider.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/files/resources/impl/DefaultResourceFilesProvider.kt
@@ -42,10 +42,10 @@ class DefaultResourceFilesProvider(
             tag,
             FileExtension.MP4.toString()
         )
-        return resourcesDirsProvider.provide(
-            resourcesRootDirsProvider.videoRootDir,
-            subDir
-        ).resolve(resFileName).createDirIfNeeded().createFileIfNeeded()
+        val resourceDir = resourcesDirsProvider.provide(resourcesRootDirsProvider.videoRootDir, subDir)
+        return resourceDir.createDirIfNeeded()
+            .resolve(resFileName)
+            .createFileIfNeeded()
     }
 
     override fun provideViewHierarchyFile(tag: String, subDir: String?): File {


### PR DESCRIPTION
Calling createDirIfNeeded() before createFileIfNeeded() caused last path element to be treated as a directory e.g. in `/path/to/test_video.mp4/` test_video.mp4 was a dir 