### PR TITLE
TECH: removed project assembly from github pull request checks

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,5 +24,3 @@ jobs:
         run: make static_analysis
       - name: Run unit tests
         run: make unit_tests
-      - name: Build project
-        run: make compile_all


### PR DESCRIPTION
No need to assemble project in github pull request checks as we do exactly the same when running UI tests on Cirrus CI