### PR TITLE
TECH: made KaspressoRunner open class

### DIFF
--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/runner/KaspressoRunner.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/runner/KaspressoRunner.kt
@@ -7,7 +7,7 @@ import com.kaspersky.kaspresso.runner.listener.KaspressoRunNotifierImpl
 import com.kaspersky.kaspresso.runner.listener.SpyRunListener
 
 @Suppress("UNUSED")
-class KaspressoRunner : AndroidJUnitRunner() {
+open class KaspressoRunner : AndroidJUnitRunner() {
 
     val runNotifier: KaspressoRunNotifier = KaspressoRunNotifierImpl()
 


### PR DESCRIPTION
In changes 1.5 you added new KaspressoRunner, but I think you forget make this open. Consumers of kaspresso framework can't use inheritance and add self logic to runner. This can be problem and as example in our company we can't update framework to 1.5 without fixing this because we need to extend logic in runner.