### PR TITLE
TECH: added new github workflow; use kaspresso snapshot dependency if…

### DIFF
--- a/.github/workflows/snapshot_check.yml
+++ b/.github/workflows/snapshot_check.yml
@@ -1,0 +1,24 @@
+# This workflow is triggered manually before release
+
+name: Snapshot Checks
+
+on: workflow_dispatch
+
+jobs:
+  snapshot-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 11
+      - name: Assemble projects
+        run: ./gradlew -PsnapshotTesting=true assembleDebugAndroidTest

--- a/.github/workflows/snapshot_check.yml
+++ b/.github/workflows/snapshot_check.yml
@@ -2,7 +2,13 @@
 
 name: Snapshot Checks
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      kaspressoVersion:
+        description: 'Kaspresso Version (for example 1.5.1-SNAPSHOT)'
+        required: true
+        type: string
 
 jobs:
   snapshot-check:
@@ -21,4 +27,4 @@ jobs:
           distribution: 'adopt'
           java-version: 11
       - name: Assemble projects
-        run: ./gradlew -PsnapshotTesting=true assembleDebugAndroidTest
+        run: ./gradlew -Pkaspresso.snapshotVersion=${{ inputs.kaspressoVersion }} assembleDebugAndroidTest

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,8 +12,14 @@ androidXTest = "1.5.0"
 testOrchestrator = "1.4.2"
 lifecycle = "2.5.1"
 thirdPartyReport = "0.17.798"
+kaspressoSnapshotVersion = "1.5.1-SNAPSHOT"
 
 [libraries]
+# kaspresso snapshots for release checks
+kaspressoSnapshot = { module =  "com.kaspersky.android-components:kaspresso", version.ref = "kaspressoSnapshotVersion" }
+allureSupportSnapshot = { module =  "com.kaspersky.android-components:kaspresso-allure-support", version.ref = "kaspressoSnapshotVersion" }
+composeSupportSnapshot = { module =  "com.kaspersky.android-components:kaspresso-compose-support", version.ref = "kaspressoSnapshotVersion" }
+
 # plugins
 kotlinPlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 androidPlugin = "com.android.tools.build:gradle:7.2.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,10 +12,8 @@ androidXTest = "1.5.0"
 testOrchestrator = "1.4.2"
 lifecycle = "2.5.1"
 thirdPartyReport = "0.17.798"
-kaspressoSnapshotVersion = "1.5.1-SNAPSHOT"
 
 [libraries]
-
 # plugins
 kotlinPlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 androidPlugin = "com.android.tools.build:gradle:7.2.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,10 +15,6 @@ thirdPartyReport = "0.17.798"
 kaspressoSnapshotVersion = "1.5.1-SNAPSHOT"
 
 [libraries]
-# kaspresso snapshots for release checks
-kaspressoSnapshot = { module =  "com.kaspersky.android-components:kaspresso", version.ref = "kaspressoSnapshotVersion" }
-allureSupportSnapshot = { module =  "com.kaspersky.android-components:kaspresso-allure-support", version.ref = "kaspressoSnapshotVersion" }
-composeSupportSnapshot = { module =  "com.kaspersky.android-components:kaspresso-compose-support", version.ref = "kaspressoSnapshotVersion" }
 
 # plugins
 kotlinPlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/samples/kaspresso-allure-support-sample/build.gradle.kts
+++ b/samples/kaspresso-allure-support-sample/build.gradle.kts
@@ -20,8 +20,14 @@ dependencies {
     implementation(libs.constraint)
     implementation(libs.multidex)
 
-    androidTestImplementation(projects.kaspresso)
-    androidTestImplementation(projects.allureSupport)
+    // kaspresso
+    if (hasProperty("snapshotTesting")) {
+        androidTestImplementation(libs.kaspressoSnapshot)
+        androidTestImplementation(libs.allureSupportSnapshot)
+    } else {
+        androidTestImplementation(projects.kaspresso)
+        androidTestImplementation(projects.allureSupport)
+    }
 
     androidTestImplementation(libs.androidXTestExtJunitKtx)
     androidTestImplementation(libs.androidXTestExtJunit)

--- a/samples/kaspresso-allure-support-sample/build.gradle.kts
+++ b/samples/kaspresso-allure-support-sample/build.gradle.kts
@@ -21,9 +21,10 @@ dependencies {
     implementation(libs.multidex)
 
     // kaspresso
-    if (hasProperty("snapshotTesting")) {
-        androidTestImplementation(libs.kaspressoSnapshot)
-        androidTestImplementation(libs.allureSupportSnapshot)
+    if (hasProperty("kaspresso.snapshotVersion")) {
+        val kaspressoVersion = property("kaspresso.snapshotVersion")
+        androidTestImplementation("com.kaspersky.android-components:kaspresso:$kaspressoVersion")
+        androidTestImplementation("com.kaspersky.android-components:kaspresso-allure-support:$kaspressoVersion")
     } else {
         androidTestImplementation(projects.kaspresso)
         androidTestImplementation(projects.allureSupport)

--- a/samples/kaspresso-compose-support-sample/build.gradle.kts
+++ b/samples/kaspresso-compose-support-sample/build.gradle.kts
@@ -52,14 +52,23 @@ dependencies {
     implementation(libs.lifecycleViewModelComposeKtx)
     implementation(libs.composeRuntimeLiveData)
 
-    androidTestImplementation(projects.kaspresso)
-    androidTestImplementation(projects.composeSupport)
+    // kaspresso
+    if (hasProperty("snapshotTesting")) {
+        testImplementation(libs.kaspressoSnapshot)
+        testImplementation(libs.composeSupportSnapshot)
+        androidTestImplementation(libs.kaspressoSnapshot)
+        androidTestImplementation(libs.composeSupportSnapshot)
+    } else {
+        testImplementation(projects.kaspresso)
+        testImplementation(projects.composeSupport)
+        androidTestImplementation(projects.kaspresso)
+        androidTestImplementation(projects.composeSupport)
+    }
+
     androidTestImplementation(libs.androidXTestRunner)
     androidTestImplementation(libs.junit)
     androidTestImplementation(libs.composeUiTestJunit)
 
-    testImplementation(projects.kaspresso)
-    testImplementation(projects.composeSupport)
     testImplementation(libs.androidXTestRunner)
     testImplementation(libs.junit)
     testImplementation(libs.composeUiTestJunit)

--- a/samples/kaspresso-compose-support-sample/build.gradle.kts
+++ b/samples/kaspresso-compose-support-sample/build.gradle.kts
@@ -53,11 +53,12 @@ dependencies {
     implementation(libs.composeRuntimeLiveData)
 
     // kaspresso
-    if (hasProperty("snapshotTesting")) {
-        testImplementation(libs.kaspressoSnapshot)
-        testImplementation(libs.composeSupportSnapshot)
-        androidTestImplementation(libs.kaspressoSnapshot)
-        androidTestImplementation(libs.composeSupportSnapshot)
+    if (hasProperty("kaspresso.snapshotVersion")) {
+        val kaspressoVersion = property("kaspresso.snapshotVersion")
+        testImplementation("com.kaspersky.android-components:kaspresso:$kaspressoVersion")
+        testImplementation("com.kaspersky.android-components:kaspresso-compose-support:$kaspressoVersion")
+        androidTestImplementation("com.kaspersky.android-components:kaspresso:$kaspressoVersion")
+        androidTestImplementation("com.kaspersky.android-components:kaspresso-compose-support:$kaspressoVersion")
     } else {
         testImplementation(projects.kaspresso)
         testImplementation(projects.composeSupport)

--- a/samples/kaspresso-sample/build.gradle.kts
+++ b/samples/kaspresso-sample/build.gradle.kts
@@ -40,14 +40,22 @@ dependencies {
     implementation(libs.androidXLifecycleRuntimeKtx)
 
     androidTestImplementation(libs.junit)
-    androidTestImplementation(projects.kaspresso)
+
+    // kaspresso
+    if (hasProperty("snapshotTesting")) {
+        androidTestImplementation(libs.kaspressoSnapshot)
+        testImplementation(libs.kaspressoSnapshot)
+    } else {
+        androidTestImplementation(projects.kaspresso)
+        testImplementation(projects.kaspresso)
+    }
+
     androidTestImplementation(libs.androidXTestRunner)
     androidTestImplementation(libs.androidXTestRules)
     androidTestImplementation(libs.androidXTestExtJunitKtx)
     androidTestImplementation(libs.androidXTestExtJunit)
 
     testImplementation(libs.junit)
-    testImplementation(projects.kaspresso)
     testImplementation(libs.androidXTestRunner)
     testImplementation(libs.androidXTestRules)
     testImplementation(libs.androidXTestExtJunitKtx)

--- a/samples/kaspresso-sample/build.gradle.kts
+++ b/samples/kaspresso-sample/build.gradle.kts
@@ -42,9 +42,10 @@ dependencies {
     androidTestImplementation(libs.junit)
 
     // kaspresso
-    if (hasProperty("snapshotTesting")) {
-        androidTestImplementation(libs.kaspressoSnapshot)
-        testImplementation(libs.kaspressoSnapshot)
+    if (hasProperty("kaspresso.snapshotVersion")) {
+        val kaspressoVersion = property("kaspresso.snapshotVersion")
+        testImplementation("com.kaspersky.android-components:kaspresso:$kaspressoVersion")
+        androidTestImplementation("com.kaspersky.android-components:kaspresso:$kaspressoVersion")
     } else {
         androidTestImplementation(projects.kaspresso)
         testImplementation(projects.kaspresso)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,7 @@ dependencyResolutionManagement {
         mavenLocal()
         google()
         maven { url = uri("https://kotlin.bintray.com/kotlinx") }
+        maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots") }
     }
 }
 


### PR DESCRIPTION
… property is set

We want to check whether the project compiles with the new kaspresso release. This PR adds a new github workflow which we would trigger manually using snapshot version before release. It assembles android tests with kaspresso, compose support and allure support being used as remote snapshot dependencies instead of the project ones. Snapshot versions usage is determined by the gradle property which we pass in the introduced workflow    