### PR TITLE
ISSUE-497: fix UiEditableActions#typeText()

### DIFF
--- a/kautomator/src/main/kotlin/com/kaspersky/components/kautomator/component/edit/UiEditableActions.kt
+++ b/kautomator/src/main/kotlin/com/kaspersky/components/kautomator/component/edit/UiEditableActions.kt
@@ -18,7 +18,7 @@ interface UiEditableActions : UiBaseActions {
         view.perform(
             UiEditableActionType.TYPE_TEXT,
             "typeText(text=$text)"
-        ) { this.text = this.text ?: "" + text }
+        ) { this.text = (this.text ?: "") + text }
     }
 
     /**

--- a/samples/kautomator-sample/src/androidTest/java/com/kaspersky/kaspresso/kautomatorsample/test/UiSimpleTest.kt
+++ b/samples/kautomator-sample/src/androidTest/java/com/kaspersky/kaspresso/kautomatorsample/test/UiSimpleTest.kt
@@ -30,6 +30,14 @@ class UiSimpleTest : TestCase() {
                     }
                 }
             }
+            step("Type more text and check it") {
+                MainScreen {
+                    simpleEditText {
+                        typeText(" is super useful")
+                        hasText("Kaspresso is super useful")
+                    }
+                }
+            }
             step("Click button") {
                 MainScreen {
                     simpleButton {


### PR DESCRIPTION
Without the parenthesis if an editText had some text already typed in, typeText method would left the original text without typing a new one 

Closes #497 