### PR TITLE
TECH: fix bug with locales in docloc tests

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ detektCli = { module = "io.gitlab.arturbosch.detekt:detekt-cli", version.ref = "
 detektFormatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 
 androidXCore = "androidx.core:core:1.9.0"
-appcompat = "androidx.appcompat:appcompat:1.5.1"
+appcompat = "androidx.appcompat:appcompat:1.6.0"
 material = "com.google.android.material:material:1.6.1"
 constraint = "androidx.constraintlayout:constraintlayout:2.1.4"
 multidex = "androidx.multidex:multidex:2.0.1"

--- a/kaspresso/build.gradle.kts
+++ b/kaspresso/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     implementation(libs.kotlinStdlib)
     implementation(libs.gson)
     implementation(projects.adbServer.adbserverDevice)
+    implementation(libs.appcompat)
 
     testImplementation(libs.junit)
     testImplementation(libs.truth)

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/languages/Language.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/languages/Language.kt
@@ -1,5 +1,6 @@
 package com.kaspersky.kaspresso.device.languages
 
+import androidx.annotation.MainThread
 import java.util.Locale
 
 /**
@@ -10,10 +11,11 @@ interface Language {
     /**
      * Switches language only in the current Application (not in OS!).
      * Please, keep in mind the following fact:
-     *   If you have switched languages then you need to refresh current screen to get the screen with new language!
+     *   If you have switched languages then activity.recreate() invoked so you have to do it on MainThread only
      *   Also, don't forget to restore the previous language if you don't clean the state of the Application after each test.
      *
      * @throws Throwable if something went wrong
      */
+    @MainThread
     fun switchInApp(locale: Locale)
 }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/languages/LanguageImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/languages/LanguageImpl.kt
@@ -1,15 +1,11 @@
 package com.kaspersky.kaspresso.device.languages
 
-import android.app.Activity
 import android.content.Context
-import android.os.Build
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.ConfigurationCompat
-import androidx.test.runner.lifecycle.ActivityLifecycleCallback
-import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
-import androidx.test.runner.lifecycle.Stage
+import androidx.core.os.LocaleListCompat
 import com.kaspersky.kaspresso.logger.UiTestLogger
-import java.lang.ref.WeakReference
-import java.util.*
+import java.util.Locale
 
 /**
  * The implementation of [Language]
@@ -18,18 +14,6 @@ class LanguageImpl(
     private val logger: UiTestLogger,
     private val context: Context
 ) : Language {
-
-    private var wRefCachedActivity: WeakReference<Activity>? = null
-    private val lifecycleCallback: ActivityLifecycleCallback =
-        ActivityLifecycleCallback { activity, stage ->
-            if (stage == Stage.CREATED) {
-                wRefCachedActivity = WeakReference(activity)
-            }
-        }
-
-    init {
-        ActivityLifecycleMonitorRegistry.getInstance().addLifecycleCallback(lifecycleCallback)
-    }
 
     override fun switchInApp(locale: Locale) {
         logger.i("Switch the language in the Application to $locale: start")
@@ -42,42 +26,27 @@ class LanguageImpl(
         }
 
         try {
-            applyCurrentLocaleToContext(
-                context = wRefCachedActivity?.get() ?: context,
-                locale = locale
-            )
+            applyCurrentLocaleToContext(locale = locale)
             logger.i("Switch the language in the Application to $locale: success")
         } catch (error: Throwable) {
             logger.e("Switch the language in the Application to $locale: failed with the error: $error")
             throw error
-        } finally {
-            wRefCachedActivity = null
         }
     }
 
     private fun getCurrentLocale(): Locale? =
         ConfigurationCompat.getLocales(context.resources.configuration).get(0)
 
-    @Suppress("DEPRECATION")
-    private fun applyCurrentLocaleToContext(context: Context, locale: Locale) {
-        // resources.updateConfiguration is deprecated method
-        // which must be replaced by createConfigurationContext method
-        // but in such a case, a developer must put created context in Application.attachBaseContext
-        // we take time to think about it
-        // details are available by this reference
-        // https://proandroiddev.com/change-language-programmatically-at-runtime-on-android-5e6bc15c758
-        val resources = context.resources
-        Locale.setDefault(locale)
-        val configuration = resources.configuration
-        configuration.setLocale(locale)
-        // For issue DocLocScreenshotTestCase does not change locale to sr-Latn-RS: https://github.com/KasperskyLab/Kaspresso/issues/389
-        // added hotfix. For next releases we will find more correct solution.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            if (locale.country.equals("Latn", true) &&
-                locale.language.equals("sr", true)) {
-                configuration.setLocale(Locale.Builder().setLanguage("sr").setScript("Latn").build())
-            }
+    private fun applyCurrentLocaleToContext(locale: Locale) {
+        /*
+        We need to change locale in tested app so AppCompatDelegate must use it's context.
+        But method setAppContext is private so we need to use reflection
+        */
+        AppCompatDelegate::class.java.getDeclaredField("sAppContext").apply {
+            isAccessible = true
+            set(null, context.applicationContext)
         }
-        resources.updateConfiguration(configuration, resources.displayMetrics)
+
+        AppCompatDelegate.setApplicationLocales(LocaleListCompat.create(locale))
     }
 }

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceLanguageSampleTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspressample/device_tests/DeviceLanguageSampleTest.kt
@@ -37,15 +37,15 @@ class DeviceLanguageSampleTest : TestCase() {
                 device.targetContext.resources.configuration.locale
             }
         }.after {
-            device.language.switchInApp(default)
+            activityRule.scenario.onActivity {
+                // it's so important to call this method on main thread
+                device.language.switchInApp(default)
+            }
         }.run {
-
             step("Change locale to english") {
-                device.language.switchInApp(Locale.ENGLISH)
-                // it's so important to reload current active Activity
-                // you can do it recreating the activity or manipulating in the Application through great Kaspresso
-                activityRule.scenario.onActivity { activity ->
-                    activity.recreate()
+                activityRule.scenario.onActivity {
+                    // it's so important to call this method on main thread
+                    device.language.switchInApp(Locale.ENGLISH)
                 }
                 Thread.sleep(SLEEP_TIME)
             }
@@ -60,11 +60,9 @@ class DeviceLanguageSampleTest : TestCase() {
             }
 
             step("Change locale to russian") {
-                device.language.switchInApp(Locale("ru"))
-                // it's so important to reload current active Activity
-                // you can do it recreating the activity or manipulating in the Application through great Kaspresso
-                activityRule.scenario.onActivity { activity ->
-                    activity.recreate()
+                activityRule.scenario.onActivity {
+                    // it's so important to call this method on main thread
+                    device.language.switchInApp(Locale("ru"))
                 }
                 Thread.sleep(SLEEP_TIME)
             }


### PR DESCRIPTION
Смена локали в скриншот тестах сейчас работает некорректно, если в конструкторе DocLocScreenshotTestCase не указать changeSystemLocale = true. На разных версиях андроид воспроизводятся разные баги, где-то игнорируется первый язык (тот что передали первым параметром в конструктор) остальные устанавливаются корректно, где-то игнорируются все языки, хотя в логах отображается, что смена произошла корректно, ни в одном случае не менялся заголовок экрана. В этом мр все проблемы пофикшены, кроме смены заголовка экрана - оно работает правильно только на версии Android API 33, похоже, что баг в библиотеке гугла, им завели ишью https://issuetracker.google.com/issues/246092030