### PR TITLE
Forcing to use correct apcompat version

### DIFF
--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/languages/LanguageImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/languages/LanguageImpl.kt
@@ -1,6 +1,9 @@
 package com.kaspersky.kaspresso.device.languages
 
+import android.app.LocaleManager
 import android.content.Context
+import android.os.Build
+import android.os.LocaleList
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.ConfigurationCompat
 import androidx.core.os.LocaleListCompat
@@ -28,7 +31,7 @@ class LanguageImpl(
         try {
             applyCurrentLocaleToContext(locale = locale)
             logger.i("Switch the language in the Application to $locale: success")
-        } catch (reflectiveException: NoSuchFieldException) {
+        } catch (e: Throwable) {
             val message = """
                 For in-app switching language you should use at least 1.6.0 version of appcompat library.
                 Please find this dependency and increase version to androidx.appcompat:appcompat:1.6.0 or higher
@@ -44,15 +47,11 @@ class LanguageImpl(
         ConfigurationCompat.getLocales(context.resources.configuration).get(0)
 
     private fun applyCurrentLocaleToContext(locale: Locale) {
-        /*
-        We need to change locale in tested app so AppCompatDelegate must use it's context.
-        But method setAppContext is private so we need to use reflection
-        */
-        AppCompatDelegate::class.java.getDeclaredField("sAppContext").apply {
-            isAccessible = true
-            set(null, context.applicationContext)
+        if (Build.VERSION.SDK_INT >= 33) {
+            val localeManager = context.getSystemService(Context.LOCALE_SERVICE) as LocaleManager
+            localeManager.applicationLocales = LocaleList.forLanguageTags(locale.toLanguageTag())
+        } else {
+            AppCompatDelegate.setApplicationLocales(LocaleListCompat.create(locale))
         }
-
-        AppCompatDelegate.setApplicationLocales(LocaleListCompat.create(locale))
     }
 }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/languages/LanguageImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/languages/LanguageImpl.kt
@@ -28,15 +28,13 @@ class LanguageImpl(
         try {
             applyCurrentLocaleToContext(locale = locale)
             logger.i("Switch the language in the Application to $locale: success")
-        }
-        catch (reflectiveException: NoSuchFieldException) {
+        } catch (reflectiveException: NoSuchFieldException) {
             val message = """
                 For in-app switching language you should use at least 1.6.0 version of appcompat library.
                 Please find this dependency and increase version to androidx.appcompat:appcompat:1.6.0 or higher
                 """.trimIndent()
             throw RuntimeException(message)
-        }
-        catch (error: Throwable) {
+        } catch (error: Throwable) {
             logger.e("Switch the language in the Application to $locale: failed with the error: $error")
             throw error
         }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/languages/LanguageImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/languages/LanguageImpl.kt
@@ -31,7 +31,7 @@ class LanguageImpl(
         try {
             applyCurrentLocaleToContext(locale = locale)
             logger.i("Switch the language in the Application to $locale: success")
-        } catch (e: Throwable) {
+        } catch (e: NoSuchMethodError) {
             val message = """
                 For in-app switching language you should use at least 1.6.0 version of appcompat library.
                 Please find this dependency and increase version to androidx.appcompat:appcompat:1.6.0 or higher

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/languages/LanguageImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/languages/LanguageImpl.kt
@@ -28,7 +28,15 @@ class LanguageImpl(
         try {
             applyCurrentLocaleToContext(locale = locale)
             logger.i("Switch the language in the Application to $locale: success")
-        } catch (error: Throwable) {
+        }
+        catch (reflectiveException: NoSuchFieldException) {
+            val message = """
+                For in-app switching language you should use at least 1.6.0 version of appcompat library.
+                Please find this dependency and increase version to androidx.appcompat:appcompat:1.6.0 or higher
+                """.trimIndent()
+            throw RuntimeException(message)
+        }
+        catch (error: Throwable) {
             logger.e("Switch the language in the Application to $locale: failed with the error: $error")
             throw error
         }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/languages/LanguageImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/languages/LanguageImpl.kt
@@ -34,7 +34,7 @@ class LanguageImpl(
         } catch (e: NoSuchMethodError) {
             val message = """
                 For in-app switching language you should use at least 1.6.0 version of appcompat library.
-                Please find this dependency and increase version to androidx.appcompat:appcompat:1.6.0 or higher
+                Please find this dependency and increase version to androidx.appcompat:appcompat:1.6.0 or higher.
                 """.trimIndent()
             throw RuntimeException(message)
         } catch (error: Throwable) {

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/languages/LanguageImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/languages/LanguageImpl.kt
@@ -47,7 +47,7 @@ class LanguageImpl(
         ConfigurationCompat.getLocales(context.resources.configuration).get(0)
 
     private fun applyCurrentLocaleToContext(locale: Locale) {
-        if (Build.VERSION.SDK_INT >= 33) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             val localeManager = context.getSystemService(Context.LOCALE_SERVICE) as LocaleManager
             localeManager.applicationLocales = LocaleList.forLanguageTags(locale.toLanguageTag())
         } else {

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/docloc/rule/ToggleNightModeRule.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/docloc/rule/ToggleNightModeRule.kt
@@ -1,12 +1,15 @@
 package com.kaspersky.kaspresso.docloc.rule
 
+import android.os.Handler
 import androidx.appcompat.app.AppCompatDelegate
+import com.kaspersky.kaspresso.device.Device
 import com.kaspersky.kaspresso.logger.UiTestLogger
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
 class ToggleNightModeRule internal constructor(
+    private val device: Device,
     private val toggleNightMode: Boolean,
     private val logger: UiTestLogger
 ) : TestRule {
@@ -14,21 +17,28 @@ class ToggleNightModeRule internal constructor(
     var isNightMode: Boolean = false
         private set
 
+    private fun turnNightMode(turnOn: Boolean) {
+        val mode = if (turnOn) AppCompatDelegate.MODE_NIGHT_YES else AppCompatDelegate.MODE_NIGHT_NO
+        Handler(device.targetContext.mainLooper).post {
+            AppCompatDelegate.setDefaultNightMode(mode)
+        }
+    }
+
     override fun apply(base: Statement, description: Description): Statement {
         return object : Statement() {
             override fun evaluate() {
                 logger.i("DocLoc: ToggleNightModeRule started")
                 try {
-                    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+                    turnNightMode(false)
                     isNightMode = false
                     base.evaluate()
                     if (toggleNightMode) {
-                        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+                        turnNightMode(true)
                         isNightMode = true
                         base.evaluate()
                     }
                 } finally {
-                    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_UNSPECIFIED)
+                    turnNightMode(false)
                     isNightMode = false
                 }
             }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/docloc/rule/ToggleNightModeRule.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/docloc/rule/ToggleNightModeRule.kt
@@ -17,8 +17,7 @@ class ToggleNightModeRule internal constructor(
     var isNightMode: Boolean = false
         private set
 
-    private fun turnNightMode(turnOn: Boolean) {
-        val mode = if (turnOn) AppCompatDelegate.MODE_NIGHT_YES else AppCompatDelegate.MODE_NIGHT_NO
+    private fun setNightMode(@AppCompatDelegate.NightMode mode: Int) {
         Handler(device.targetContext.mainLooper).post {
             AppCompatDelegate.setDefaultNightMode(mode)
         }
@@ -29,16 +28,16 @@ class ToggleNightModeRule internal constructor(
             override fun evaluate() {
                 logger.i("DocLoc: ToggleNightModeRule started")
                 try {
-                    turnNightMode(false)
+                    setNightMode(AppCompatDelegate.MODE_NIGHT_NO)
                     isNightMode = false
                     base.evaluate()
                     if (toggleNightMode) {
-                        turnNightMode(true)
+                        setNightMode(AppCompatDelegate.MODE_NIGHT_YES)
                         isNightMode = true
                         base.evaluate()
                     }
                 } finally {
-                    turnNightMode(false)
+                    setNightMode(AppCompatDelegate.MODE_NIGHT_UNSPECIFIED)
                     isNightMode = false
                 }
             }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/api/testcase/DocLocScreenshotTestCase.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/testcases/api/testcase/DocLocScreenshotTestCase.kt
@@ -137,7 +137,8 @@ abstract class DocLocScreenshotTestCase(
     @get:Rule
     val nightModeRule = ToggleNightModeRule(
         toggleNightMode = toggleNightMode,
-        logger = kaspresso.libLogger
+        logger = kaspresso.libLogger,
+        device = kaspresso.device
     )
 
     @get:Rule


### PR DESCRIPTION
In order to use in-app switching language in screenshot-tests you have to use 1.6.0 version of appcompat library or higher. In this request we added explanation to exception what they should do if they caught NoSuchFieldException