### PR TITLE
TECH: hardcode plugin version

### DIFF
--- a/.github/workflows/tutorial.yml
+++ b/.github/workflows/tutorial.yml
@@ -12,5 +12,5 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install mkdocs-material
-      - run: pip install mkdocs-static-i18n
+      - run: pip install mkdocs-static-i18n==0.56
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
После каждого пуша в мастер происходит публикация tutorial на сайт https://kasperskylab.github.io/. В текущей реализации в мастере берется последняя версия плагина mkdocs-static-i18n. Которая до недавнего времени работала нормально, а сейчас выкатили обновление, которое полностью ломает структуру туториола, на большистве страниц отображается 404, а где-то просто едет верстка. Поэтому в данном реквесте мы указываем использовать старую, рабочую версию плагина