### PR TITLE
Fix tutorial.yml

### DIFF
--- a/.github/workflows/tutorial.yml
+++ b/.github/workflows/tutorial.yml
@@ -2,7 +2,7 @@ name: tutorial
 on:
   push:
     branches:
-      - TECH-fix-tutorial
+      - master
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/tutorial.yml
+++ b/.github/workflows/tutorial.yml
@@ -2,7 +2,7 @@ name: tutorial
 on:
   push:
     branches:
-      - master
+      - TECH-fix-tutorial
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+redirect_to: /en/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,10 +1,10 @@
 site_name: "Kaspresso"
 repo_url: https://github.com/KasperskyLab/Kaspresso
 repo_name: Kaspresso
+site_url: https://kasperskylab.github.io/Kaspresso/
 edit_uri: tree/main/docs/content
 docs_dir: 'docs'
 remote_branch: gh-pages
-language: en
 
 theme:
   favicon: kaspresso.png
@@ -38,7 +38,6 @@ theme:
   search_index_only: true
 
   # Default values, taken from mkdocs_theme.yml
-  language: ru
   font:
     text: Roboto
     code: Roboto Mono


### PR DESCRIPTION
Удалил ненужные тэги из tutorial.yml + важное изменение - редирект. Если пользователь переходил по адресу https://kasperskylab.github.io/Kaspresso без явного указания языка (.../en/), то навигация по сайту не работала, страницы туториала, вики и т.д. работали некорректно