### PR TITLE
Fixed Allure support documentation for Russian and English languages

### DIFF
--- a/docs/Wiki/Kaspresso_Allure.en.md
+++ b/docs/Wiki/Kaspresso_Allure.en.md
@@ -81,13 +81,19 @@ class AllureSupportCustomizeTest : TestCase(
 [**kaspresso-allure-support-sample**](https://github.com/KasperskyLab/Kaspresso/tree/master/samples/kaspresso-allure-support-sample/src/androidTest/kotlin/com/kaspersky/kaspresso/alluresupport/sample) is available to watch, to launch and to experiment with all of this staff.
 
 ## Watch result
-So you added the list of needed Allure-supporting interceptors to your Kaspresso configuration and launched the test. After the test finishes there will be **sdcard/allure-results** dir created on the device with all the files processed to be included to Allure-report.
-
+So you added the list of needed Allure-supporting interceptors to your Kaspresso configuration and launched the test. After the test finishes there will be **/data/data/(your package)/files/allure-results** dir created on the device with all the files processed to be included to Allure-report.
+If your tests are configured to clear app data with Orchestrator and you want to avoid your results directory getting cleared alongside, or you want a shorter path:
+- Add `androidTestUtil("androidx.test:orchestrator:VERSION}` to your dependencies
+- Create **resources** (not **res**) folder under **androidTest**, there create a file named **allure.properties** and put this line in the file:
+```
+allure.results.useTestStorage=true
+```
+Now your tests are saved under **/sdcard/googletest/test_outputfiles/allure-results**
 This dir should be moved from the device to the host machine which will do generate the report.
 
 For example, you can use **adb pull** command on your host for this. Let say you want to locate the data for the report at **/Users/username/Desktop/allure-results**, so you call:
 ```
-adb pull /sdcard/allure-results /Users/username/Desktop
+adb pull /sdcard/googletest/test_outputfiles/allure-results /Users/username/Desktop
 ```
 If there are few devices connected to yout host you should specify the needed device id. To watch the list of connected devices you can call:
 ```
@@ -101,7 +107,7 @@ emulator-5554	device
 ```
 Select the needed device and call:
 ```
-adb -s emulator-5554 pull /sdcard/allure-results /Users/username/Desktop
+adb -s emulator-5554 pull /sdcard/googletest/test_outputfiles/allure-results /Users/username/Desktop
 ```
 And that's it, the **allure-results** dir with all the test resources is now at **/Users/username/Desktop**.
 

--- a/docs/Wiki/Kaspresso_Allure.ru.md
+++ b/docs/Wiki/Kaspresso_Allure.ru.md
@@ -81,13 +81,21 @@ class AllureSupportCustomizeTest : TestCase(
 Для просмотра, запуска и экспериментирования со всем этим функционалом вам доступен [**kaspresso-allure-support-sample**](https://github.com/KasperskyLab/Kaspresso/tree/master/samples/kaspresso-allure-support-sample/src/androidTest/kotlin/com/kaspersky/kaspresso/alluresupport/sample).
 
 ## Посмотреть результат
-Итак, вы добавили в свою конфигурацию Kaspresso список необходимых перехватчиков, поддерживающих Allure, и запустили тест. После завершения теста на устройстве будет создан каталог **sdcard/allure-results** со всеми обработанными файлами, которые будут включены в отчет Allure.
+Итак, вы добавили в свою конфигурацию Kaspresso список необходимых перехватчиков, поддерживающих Allure, и запустили тест. После завершения теста на устройстве будет создан каталог **data/data/(ваш пакет)/files/allure-results** со всеми обработанными файлами, которые будут включены в отчет Allure.
+Если в ваших тестах вы настроили очищение app data при помощи Orchestrator и не хотите, чтобы результаты тестов очищались вместе с данными приложения или просто хотите путь короче:
+
+- Добавьте `androidTestUtil("androidx.test:orchestrator:VERSION}` к вашим зависимостям
+- Создайте папку **resources** (не **res**) в папке **androidTest**, в новой папке создайте файл с названием **allure.properties** и измените его содержимое следующим образом:
+```
+allure.results.useTestStorage=true
+```
+Теперь результаты тестов будут храниться в **/sdcard/googletest/test_outputfiles/allure-results**
 
 Этот каталог следует переместить с устройства на хост-компьютер, который будет генерировать отчет.
 
 Например, вы можете использовать для этого команду **adb pull** на своем хосте. Допустим, вы хотите найти данные для отчета в **/Users/username/Desktop/allure-results**, поэтому вы вызываете:
 ```
-adb pull /sdcard/allure-results /Users/username/Desktop
+adb pull /sdcard/googletest/test_outputfiles/allure-results /Users/username/Desktop
 ```
 Если к вашему хосту подключено несколько устройств, вы должны указать нужный идентификатор устройства. Для просмотра списка подключенных устройств вы можете выполнить:
 ```
@@ -101,7 +109,7 @@ emulator-5554	device
 ```
 Выберите необходимое устройство и вызовите:
 ```
-adb -s emulator-5554 pull /sdcard/allure-results /Users/username/Desktop
+adb -s emulator-5554 pull /sdcard/googletest/test_outputfiles/allure-results /Users/username/Desktop
 ```
 Вот и все, директория **allure-results** со всеми тестовыми ресурсами теперь находится по адресу **/Users/username/Desktop**.
 


### PR DESCRIPTION
Hello!

First of all, thank you for your work. This framework looks really promising for our project!

When I was adding Kaspresso with Allure support to our project I was a bit discouraged by the fact that no matter what configuration I picked there was no /sdcard/allure-results directory. I've searched across numerous repositories and found this: https://github.com/allure-framework/allure-kotlin/tree/master

In a nutshell, this repository mentions directories like this in readme:

> results are saved in an app files directory, e.g. /data/data/com.example/files/allure-results.
> ...allure will use TestStorage to save test results. Test results will be saved by default into /sdcard/googletest/test_outputfiles/allure-results

So, this PR contains some additions/changes in documentation so it represents allure's instructions on test results location

If it does matter I've encountered a problem with this config:
* Custom hilt runner implementing KaspressoRunner, overrides newApplication()
* Kaspresso 1.5.3
* Kaspresso builder -> Kaspresso.Builder.withForcedAllureSupport()
* Test case annotated with @HiltAndroidTest

Everything else is pretty basic as I stumbled upon this on a dummy test