### PR TITLE
ISSUE-652: define ALLOW_ALL & ALLOW_SELECTED on Permissions.Button

### DIFF
--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/permissions/Permissions.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/permissions/Permissions.kt
@@ -29,6 +29,8 @@ interface Permissions {
         ALLOW,
         ALLOW_ALWAYS,
         ALLOW_FOREGROUND,
+        ALLOW_ALL,
+        ALLOW_SELECTED,
         DENY
     }
 }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/permissions/PermissionsImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/permissions/PermissionsImpl.kt
@@ -34,6 +34,8 @@ class PermissionsImpl(
         Permissions.Button.ALLOW to getResIdWithPackageName("permission_allow_button"),
         Permissions.Button.ALLOW_ALWAYS to getResIdWithPackageName("permission_allow_always_button"),
         Permissions.Button.ALLOW_FOREGROUND to getResIdWithPackageName("permission_allow_foreground_only_button"),
+        Permissions.Button.ALLOW_ALL to getResIdWithPackageName("permission_allow_all_button"),
+        Permissions.Button.ALLOW_SELECTED to getResIdWithPackageName("permission_allow_selected_button"),
         Permissions.Button.DENY to getResIdWithPackageName("permission_deny_button")
     )
 


### PR DESCRIPTION
The enum object for **"Select photos and videos" & "Allow all"**, 
which was added for photos and videos since Android 14, is not defined yet.
So I defined them in `Permissions.Button`
After implementing it, I verified that it works properly.


Please check out [this](https://developer.android.com/about/versions/14/changes/partial-photo-video-access)




Closes #652