### PR TITLE
ISSUE-690: Add DENY_AND_DONT_ASK permission button resource

### DIFF
--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/permissions/Permissions.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/permissions/Permissions.kt
@@ -34,6 +34,7 @@ interface Permissions {
         ALLOW_FOREGROUND,
         ALLOW_ALL,
         ALLOW_SELECTED,
-        DENY
+        DENY,
+        DENY_AND_DONT_ASK,
     }
 }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/permissions/PermissionsImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/permissions/PermissionsImpl.kt
@@ -36,7 +36,8 @@ class PermissionsImpl(
         Permissions.Button.ALLOW_FOREGROUND to getResIdWithPackageName("permission_allow_foreground_only_button"),
         Permissions.Button.ALLOW_ALL to getResIdWithPackageName("permission_allow_all_button"),
         Permissions.Button.ALLOW_SELECTED to getResIdWithPackageName("permission_allow_selected_button"),
-        Permissions.Button.DENY to getResIdWithPackageName("permission_deny_button")
+        Permissions.Button.DENY to getResIdWithPackageName("permission_deny_button"),
+        Permissions.Button.DENY_AND_DONT_ASK to getResIdWithPackageName("permission_deny_and_dont_ask_again_button")
     )
 
     /**


### PR DESCRIPTION
New enum for permission_deny_and_dont_ask_again_button resource
Allows UI automation for cases with multiple permission denies.

Closes https://github.com/KasperskyLab/Kaspresso/issues/690