### PR TITLE
Upgrade Material dependency to version 1.12.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ core-ktx = "1.9.0"
 junit = "4.13.2"
 androidx-test-ext-junit = "1.1.5"
 appcompat = "1.6.1"
-material = "1.8.0"
+material = "1.12.0"
 
 [libraries]
 # plugins


### PR DESCRIPTION
Fixes #578 (according to a comment, at least)

I recommend adding Dependabot or Renovate to automatically handle dependency upgrades.