### PR TITLE
ISSUE-717: Add "don't ask again" Deny button in Permissions

### DIFF
--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/permissions/Permissions.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/permissions/Permissions.kt
@@ -16,7 +16,7 @@ interface Permissions {
     /**
      * Passes the permission-requesting permissions dialog and denies permissions.
      */
-    fun denyViaDialog()
+    fun denyViaDialog(button: Button = Button.DENY)
 
     /**
      * Check the permission-requesting permissions dialog is visible.
@@ -34,6 +34,7 @@ interface Permissions {
         ALLOW_FOREGROUND,
         ALLOW_ALL,
         ALLOW_SELECTED,
-        DENY
+        DENY,
+        DENY_AND_DONT_ASK_AGAIN
     }
 }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/permissions/PermissionsImpl.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/permissions/PermissionsImpl.kt
@@ -36,7 +36,8 @@ class PermissionsImpl(
         Permissions.Button.ALLOW_FOREGROUND to getResIdWithPackageName("permission_allow_foreground_only_button"),
         Permissions.Button.ALLOW_ALL to getResIdWithPackageName("permission_allow_all_button"),
         Permissions.Button.ALLOW_SELECTED to getResIdWithPackageName("permission_allow_selected_button"),
-        Permissions.Button.DENY to getResIdWithPackageName("permission_deny_button")
+        Permissions.Button.DENY to getResIdWithPackageName("permission_deny_button"),
+        Permissions.Button.DENY_AND_DONT_ASK_AGAIN to getResIdWithPackageName("permission_deny_and_dont_ask_again_button")
     )
 
     /**
@@ -55,12 +56,12 @@ class PermissionsImpl(
     /**
      * Waits for 1 sec, passes the permission-requesting permissions dialog and denies permissions.
      */
-    override fun denyViaDialog() {
+    override fun denyViaDialog(button: Permissions.Button) {
         wait(
             timeoutMs = DIALOG_TIMEOUT_MS,
             logger = logger
         ) {
-            handlePermissionRequest(Permissions.Button.DENY)
+            handlePermissionRequest(button)
         }
         logger.i("Deny permission via dialog")
     }


### PR DESCRIPTION
Fixes #717

Arguably, `allowViaDialog` and `denyViaDialog` are rather redundant, since they just do the same thing as `clickButton`, only providing default arguments.