### PR TITLE
ISSUE-733: Add configurable screenshotMaker to Kaspresso.Builder

### DIFF
--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/screenshots/screenshotmaker/ExternalScreenshotMaker.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/screenshots/screenshotmaker/ExternalScreenshotMaker.kt
@@ -1,6 +1,5 @@
 package com.kaspersky.kaspresso.device.screenshots.screenshotmaker
 
-import android.app.Instrumentation
 import androidx.test.uiautomator.UiDevice
 import com.kaspersky.kaspresso.instrumental.InstrumentalDependencyProvider
 import com.kaspersky.kaspresso.params.ScreenshotParams
@@ -19,19 +18,28 @@ class ExternalScreenshotMaker(
 ) : ScreenshotMaker {
 
     /**
-     * Creates an [ExternalScreenshotMaker] from an [Instrumentation] instance.
+     * Creates an [ExternalScreenshotMaker] from a [UiDevice] instance.
      *
      * This is a convenience constructor for use in [com.kaspersky.kaspresso.kaspresso.Kaspresso.Builder]:
      * ```
      * Kaspresso.Builder.simple {
-     *     screenshotMaker = ExternalScreenshotMaker(instrumentation)
+     *     screenshotMaker = ExternalScreenshotMaker(UiDevice.getInstance(instrumentation))
      * }
      * ```
      */
     constructor(
-        instrumentation: Instrumentation,
+        uiDevice: UiDevice,
         params: ScreenshotParams = ScreenshotParams()
-    ) : this(SimpleUiDeviceProvider(instrumentation), params)
+    ) : this(
+        object : InstrumentalDependencyProvider {
+            override val isAndroidRuntime = true
+            override val uiDevice get() = uiDevice
+            override val uiAutomation get() = throw UnsupportedOperationException()
+            override val runNotifier get() = throw UnsupportedOperationException()
+            override fun getUiAutomation(flags: Int) = throw UnsupportedOperationException()
+        },
+        params
+    )
 
     private val device: UiDevice
         get() = instrumentalDependencyProvider.uiDevice
@@ -45,18 +53,4 @@ class ExternalScreenshotMaker(
     }
 
     override fun takeFullWindowScreenshot(file: File) = takeScreenshot(file)
-
-    /**
-     * Minimal [InstrumentalDependencyProvider] that only provides [UiDevice].
-     * Used by the [Instrumentation]-based constructor to avoid depending on the full provider implementation.
-     */
-    private class SimpleUiDeviceProvider(
-        private val instrumentation: Instrumentation
-    ) : InstrumentalDependencyProvider {
-        override val isAndroidRuntime: Boolean = true
-        override val uiDevice: UiDevice get() = UiDevice.getInstance(instrumentation)
-        override val uiAutomation get() = instrumentation.uiAutomation
-        override val runNotifier get() = throw UnsupportedOperationException()
-        override fun getUiAutomation(flags: Int) = instrumentation.getUiAutomation(flags)
-    }
 }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/screenshots/screenshotmaker/ExternalScreenshotMaker.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/device/screenshots/screenshotmaker/ExternalScreenshotMaker.kt
@@ -1,5 +1,6 @@
 package com.kaspersky.kaspresso.device.screenshots.screenshotmaker
 
+import android.app.Instrumentation
 import androidx.test.uiautomator.UiDevice
 import com.kaspersky.kaspresso.instrumental.InstrumentalDependencyProvider
 import com.kaspersky.kaspresso.params.ScreenshotParams
@@ -7,11 +8,30 @@ import java.io.File
 
 /**
  * Captures spoon-compatible screenshots by uiautomator.
+ *
+ * Unlike [InternalScreenshotMaker] which only captures the main activity window,
+ * this maker uses [UiDevice.takeScreenshot] to capture the full device screen,
+ * including popup windows such as Material ModalBottomSheet.
  */
 class ExternalScreenshotMaker(
     private val instrumentalDependencyProvider: InstrumentalDependencyProvider,
     private val params: ScreenshotParams = ScreenshotParams()
 ) : ScreenshotMaker {
+
+    /**
+     * Creates an [ExternalScreenshotMaker] from an [Instrumentation] instance.
+     *
+     * This is a convenience constructor for use in [com.kaspersky.kaspresso.kaspresso.Kaspresso.Builder]:
+     * ```
+     * Kaspresso.Builder.simple {
+     *     screenshotMaker = ExternalScreenshotMaker(instrumentation)
+     * }
+     * ```
+     */
+    constructor(
+        instrumentation: Instrumentation,
+        params: ScreenshotParams = ScreenshotParams()
+    ) : this(SimpleUiDeviceProvider(instrumentation), params)
 
     private val device: UiDevice
         get() = instrumentalDependencyProvider.uiDevice
@@ -24,7 +44,19 @@ class ExternalScreenshotMaker(
         device.takeScreenshot(file, scale, params.quality)
     }
 
-    override fun takeFullWindowScreenshot(file: File) {
-        TODO("External Full Window Screenshot not yet implemented")
+    override fun takeFullWindowScreenshot(file: File) = takeScreenshot(file)
+
+    /**
+     * Minimal [InstrumentalDependencyProvider] that only provides [UiDevice].
+     * Used by the [Instrumentation]-based constructor to avoid depending on the full provider implementation.
+     */
+    private class SimpleUiDeviceProvider(
+        private val instrumentation: Instrumentation
+    ) : InstrumentalDependencyProvider {
+        override val isAndroidRuntime: Boolean = true
+        override val uiDevice: UiDevice get() = UiDevice.getInstance(instrumentation)
+        override val uiAutomation get() = instrumentation.uiAutomation
+        override val runNotifier get() = throw UnsupportedOperationException()
+        override fun getUiAutomation(flags: Int) = instrumentation.getUiAutomation(flags)
     }
 }

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/kaspresso/Kaspresso.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/kaspresso/Kaspresso.kt
@@ -495,7 +495,7 @@ data class Kaspresso(
          * UiDevice-based capture which includes popup windows like ModalBottomSheet:
          * ```
          * Kaspresso.Builder.simple {
-         *     screenshotMaker = ExternalScreenshotMaker(instrumentation)
+         *     screenshotMaker = ExternalScreenshotMaker(UiDevice.getInstance(instrumentation))
          * }
          * ```
          */

--- a/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/kaspresso/Kaspresso.kt
+++ b/kaspresso/src/main/kotlin/com/kaspersky/kaspresso/kaspresso/Kaspresso.kt
@@ -44,6 +44,7 @@ import com.kaspersky.kaspresso.device.screenshots.ScreenshotsImpl
 import com.kaspersky.kaspresso.device.screenshots.screenshotmaker.CombinedScreenshotMaker
 import com.kaspersky.kaspresso.device.screenshots.screenshotmaker.ExternalScreenshotMaker
 import com.kaspersky.kaspresso.device.screenshots.screenshotmaker.InternalScreenshotMaker
+import com.kaspersky.kaspresso.device.screenshots.screenshotmaker.ScreenshotMaker
 import com.kaspersky.kaspresso.device.server.AdbServer
 import com.kaspersky.kaspresso.device.server.AdbServerImpl
 import com.kaspersky.kaspresso.device.video.Videos
@@ -486,6 +487,21 @@ data class Kaspresso(
         lateinit var screenshotParams: ScreenshotParams
 
         /**
+         * Holds an implementation of [ScreenshotMaker] for capturing screenshots.
+         * If it was not specified, a [CombinedScreenshotMaker] using internal (Activity.decorView)
+         * and external (UiDevice) capture is used.
+         *
+         * Override this to control how screenshots are captured — for example, to always use
+         * UiDevice-based capture which includes popup windows like ModalBottomSheet:
+         * ```
+         * Kaspresso.Builder.simple {
+         *     screenshotMaker = ExternalScreenshotMaker(instrumentation)
+         * }
+         * ```
+         */
+        lateinit var screenshotMaker: ScreenshotMaker
+
+        /**
          * Holds the [VideoParams] for [com.kaspersky.kaspresso.device.video.recorder.VideoRecorder]'s usage.
          * If it was not specified, the default implementation is used.
          */
@@ -803,17 +819,21 @@ data class Kaspresso(
             )
             if (!::visualTestWatcher.isInitialized) visualTestWatcher = DefaultVisualTestWatcher(visualTestParams, libLogger, dirsProvider, resourcesRootDirsProvider, files)
 
+            if (!::screenshotMaker.isInitialized) {
+                screenshotMaker = CombinedScreenshotMaker(
+                    preferredScreenshotMaker = InternalScreenshotMaker(activities, screenshotParams),
+                    fallbackScreenshotMaker = ExternalScreenshotMaker(
+                        instrumentalDependencyProviderFactory.getComponentProvider<ExternalScreenshotMaker>(instrumentation),
+                        screenshotParams
+                    )
+                )
+            }
+
             if (!::screenshots.isInitialized) {
                 screenshots = ScreenshotsImpl(
                     logger = libLogger,
                     resourceFilesProvider = resourceFilesProvider,
-                    screenshotMaker = CombinedScreenshotMaker(
-                        preferredScreenshotMaker = InternalScreenshotMaker(activities, screenshotParams),
-                        fallbackScreenshotMaker = ExternalScreenshotMaker(
-                            instrumentalDependencyProviderFactory.getComponentProvider<ExternalScreenshotMaker>(instrumentation),
-                            screenshotParams
-                        )
-                    ),
+                    screenshotMaker = screenshotMaker,
                     visualTestParams = visualTestParams,
                     screenshotsComparator = screenshotsComparator,
                     dirsProvider = dirsProvider,

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspresso/sanity/device/ExternalScreenshotMakerSanityTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspresso/sanity/device/ExternalScreenshotMakerSanityTest.kt
@@ -1,0 +1,70 @@
+package com.kaspersky.kaspresso.sanity.device
+
+import androidx.test.ext.junit.rules.activityScenarioRule
+import com.kaspersky.kaspressample.device.DeviceSampleActivity
+import com.kaspersky.kaspresso.device.screenshots.screenshotmaker.ExternalScreenshotMaker
+import com.kaspersky.kaspresso.kaspresso.Kaspresso
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+
+class ExternalScreenshotMakerSanityTest : TestCase(
+    kaspressoBuilder = Kaspresso.Builder.advanced {
+        screenshotMaker = ExternalScreenshotMaker(instrumentation)
+    }
+) {
+
+    companion object {
+        private const val SCREENSHOT_TAG = "external_screenshot"
+        private const val FULL_SCREENSHOT_TAG = "external_full_screenshot"
+    }
+
+    @get:Rule
+    val activityRule = activityScenarioRule<DeviceSampleActivity>()
+
+    @Test
+    fun externalScreenshotTest() {
+        val screenshotDir = resourceFilesProvider.provideScreenshotFile(SCREENSHOT_TAG).parentFile
+            ?: throw Exception("Invalid screenshot file, no parent dir")
+
+        before {
+            deleteDir(screenshotDir)
+        }.after {
+        }.run {
+            assertTrue(screenshotDir.list()?.isEmpty() ?: true)
+            step("Take screenshot with ExternalScreenshotMaker") {
+                device.screenshots.take(SCREENSHOT_TAG)
+                assertTrue(resourceFilesProvider.provideScreenshotFile(SCREENSHOT_TAG).exists())
+            }
+        }
+    }
+
+    @Test
+    fun externalFullWindowScreenshotTest() {
+        val screenshotDir = resourceFilesProvider.provideScreenshotFile(FULL_SCREENSHOT_TAG).parentFile
+            ?: throw Exception("Invalid screenshot file, no parent dir")
+
+        before {
+            deleteDir(screenshotDir)
+        }.after {
+        }.run {
+            assertTrue(screenshotDir.list()?.isEmpty() ?: true)
+            step("Take full window screenshot with ExternalScreenshotMaker") {
+                device.screenshots.takeFullWindow(FULL_SCREENSHOT_TAG)
+                assertTrue(resourceFilesProvider.provideScreenshotFile(FULL_SCREENSHOT_TAG).exists())
+            }
+        }
+    }
+
+    private fun deleteDir(dir: File?) {
+        if (dir == null || !dir.exists()) return
+
+        dir.listFiles()?.forEach { file ->
+            if (file.isDirectory) deleteDir(file)
+            if (file.isFile) file.delete()
+        }
+        dir.delete()
+    }
+}

--- a/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspresso/sanity/device/ExternalScreenshotMakerSanityTest.kt
+++ b/samples/kaspresso-sample/src/androidTest/kotlin/com/kaspersky/kaspresso/sanity/device/ExternalScreenshotMakerSanityTest.kt
@@ -1,6 +1,7 @@
 package com.kaspersky.kaspresso.sanity.device
 
 import androidx.test.ext.junit.rules.activityScenarioRule
+import androidx.test.uiautomator.UiDevice
 import com.kaspersky.kaspressample.device.DeviceSampleActivity
 import com.kaspersky.kaspresso.device.screenshots.screenshotmaker.ExternalScreenshotMaker
 import com.kaspersky.kaspresso.kaspresso.Kaspresso
@@ -12,7 +13,7 @@ import java.io.File
 
 class ExternalScreenshotMakerSanityTest : TestCase(
     kaspressoBuilder = Kaspresso.Builder.advanced {
-        screenshotMaker = ExternalScreenshotMaker(instrumentation)
+        screenshotMaker = ExternalScreenshotMaker(UiDevice.getInstance(instrumentation))
     }
 ) {
 


### PR DESCRIPTION
Closes #733

## Summary

- Add `lateinit var screenshotMaker: ScreenshotMaker` to `Kaspresso.Builder`, following the same `if (!::prop.isInitialized)` pattern used by other Builder properties. Default behavior is unchanged.
- Add a secondary constructor to `ExternalScreenshotMaker` that accepts `Instrumentation` directly, so users don't need to deal with `InstrumentalDependencyProvider`.
- Fix `ExternalScreenshotMaker.takeFullWindowScreenshot` which previously threw `TODO("not yet implemented")`. Since `UiDevice.takeScreenshot()` already captures the full screen, it delegates to `takeScreenshot()`.

## Usage

```kotlin
Kaspresso.Builder.advanced {
    screenshotMaker = ExternalScreenshotMaker(instrumentation)
}
```

## Test plan

- [ ] Verify default behavior is unchanged: `Kaspresso.Builder.simple {}` and `advanced {}` without setting `screenshotMaker` should produce the same `CombinedScreenshotMaker` as before
- [ ] Verify custom screenshotMaker: setting `screenshotMaker = ExternalScreenshotMaker(instrumentation)` in `simple {}` or `advanced {}` uses UiDevice-based capture
- [ ] Verify popup windows (e.g. ModalBottomSheet) are visible in screenshots when using `ExternalScreenshotMaker`
- [ ] Verify `takeFullWindowScreenshot` no longer throws on `ExternalScreenshotMaker`